### PR TITLE
refactor(api): Rename latest version endpoint for clarity

### DIFF
--- a/Backend/routes/api.php
+++ b/Backend/routes/api.php
@@ -169,7 +169,7 @@ Route::middleware('auth:api')->post('manual-sms/{salon}/send', [ManualSmsControl
 Route::post('/payment/purchase/{packageId}', [ZarinpalController::class, 'purchase']);
 Route::post('/payment/callback', [ZarinpalController::class, 'callback']);
 
-Route::get('/latest-version', [AppController::class, 'latestVersion']);
+Route::get('/app-latest-version', [AppController::class, 'latestVersion']);
 
 Route::get('/notifications', [NotificationController::class, 'index']);
 


### PR DESCRIPTION
Change the API route from `/latest-version` to `/app-latest-version`.

The original name was too generic. This update makes the endpoint more specific to the application version, improving clarity and preventing potential future naming conflicts.