### PR TITLE
db: Add sms_count to sms_transactions table

### DIFF
--- a/Backend/database/migrations/2025_08_17_092758_add_sms_count_to_sms_transactions_table.php
+++ b/Backend/database/migrations/2025_08_17_092758_add_sms_count_to_sms_transactions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sms_transactions', function (Blueprint $table) {
+            $table->integer('sms_count')->nullable()->after('amount');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sms_transactions', function (Blueprint $table) {
+            $table->dropColumn('sms_count');
+        });
+    }
+};


### PR DESCRIPTION
This commit introduces a new migration to add an `sms_count` integer column to the `sms_transactions` table.

This column will store the number of SMS segments that a single message transaction consists of. This is necessary for more accurate billing and usage tracking, especially for messages that exceed the standard character limit and are sent as multiple parts.