### PR TITLE
Refactor: Use purchase callback for Zarinpal payments

### DIFF
--- a/Backend/app/Http/Controllers/ZarinpalController.php
+++ b/Backend/app/Http/Controllers/ZarinpalController.php
@@ -60,15 +60,15 @@ class ZarinpalController extends Controller
             $payment = Payment::via('zarinpal')->callbackUrl($request->callback_url);
 
             // 2. Prepare the invoice and the transaction callback.
-            $payment->purchase($invoice);
+            $payment->purchase(
+                $invoice,
+                function ($driver, $transactionId) use ($transaction) {
+                    // Store the gateway transaction ID (Authority)
+                    $transaction->update(['transaction_id' => $transactionId]);
+                }
+            );
 
-            // 3. Get the transaction ID (Authority) from the driver.
-            $transactionId = $payment->getTransactionId();
-
-            // 4. Store the gateway transaction ID.
-            $transaction->update(['transaction_id' => $transactionId]);
-
-            // 5. Generate the redirection form.
+            // 3. Generate the redirection form.
             $redirectionForm = $payment->pay();
 
             // 4. Get the payment URL from the redirection form by casting it to a string.


### PR DESCRIPTION
Update the Zarinpal purchase method to leverage the built-in callback functionality of the payment library.

Instead of making separate calls to get the transaction ID and then update the database, this logic is now handled within a closure passed directly to the `purchase` method. This simplifies the code, makes the process more atomic, and ensures the gateway transaction ID is stored immediately upon creation.