### PR TITLE
db: Add reference_id and description to sms_transactions

### DIFF
--- a/Backend/database/migrations/2025_08_18_025003_add_reference_id_and_description_to_sms_transactions_table.php
+++ b/Backend/database/migrations/2025_08_18_025003_add_reference_id_and_description_to_sms_transactions_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('sms_transactions', function (Blueprint $table) {
+            $table->string('reference_id')->nullable()->after('transaction_id');
+            $table->text('description')->nullable()->after('reference_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('sms_transactions', function (Blueprint $table) {
+            $table->dropColumn(['reference_id', 'description']);
+        });
+    }
+};


### PR DESCRIPTION
This commit introduces a new migration to add `reference_id` and `description` columns to the `sms_transactions` table.

The `reference_id` will be used to store an external identifier for better traceability with third-party services. The `description` column allows for storing a human-readable summary of the transaction, which aids in debugging and auditing.