### PR TITLE
refactor(Appointment): Eager load relations and format date

### DIFF
--- a/Backend/app/Http/Controllers/AppointmentDetailsController.php
+++ b/Backend/app/Http/Controllers/AppointmentDetailsController.php
@@ -10,6 +10,7 @@ class AppointmentDetailsController extends Controller
     public function showByHash($hash)
     {
         $appointment = Appointment::where('hash', $hash)->firstOrFail();
+        $appointment->load(['customer', 'salon', 'services', 'staff']);
         // Here you would typically return a view with the appointment details
         return view('appointments.details', compact('appointment'));
     }

--- a/Backend/app/Models/Appointment.php
+++ b/Backend/app/Models/Appointment.php
@@ -89,6 +89,11 @@ class Appointment extends Model
         return null;
     }
 
+    public function getAppointmentDateAttribute($value)
+    {
+        return \Carbon\Carbon::parse($value)->format('Y-m-d');
+    }
+
     // Scopes
     public function scopeMonthlyCount($query, $year, $month)
     {


### PR DESCRIPTION
Eager load the `customer`, `salon`, `services`, and `staff` relationships in the `AppointmentDetailsController` to prevent N+1 query issues and improve performance on the details page.

Add an accessor to the `Appointment` model to consistently format the `appointment_date` attribute as 'Y-m-d', ensuring correct display.