### PR TITLE
Refactor: Simplify appointment date and time handling

### DIFF
--- a/Backend/app/Models/Appointment.php
+++ b/Backend/app/Models/Appointment.php
@@ -89,11 +89,6 @@ class Appointment extends Model
         return null;
     }
 
-    public function getAppointmentDateAttribute($value)
-    {
-        return \Carbon\Carbon::parse($value)->format('Y-m-d');
-    }
-
     // Scopes
     public function scopeMonthlyCount($query, $year, $month)
     {

--- a/Backend/resources/views/appointments/details.blade.php
+++ b/Backend/resources/views/appointments/details.blade.php
@@ -6,7 +6,7 @@
     <title>جزئیات نوبت</title>
     <meta name="lat" content="{{ $appointment->salon->lat ?? 35.7219 }}">
     <meta name="lang" content="{{ $appointment->salon->lang ?? 51.3347 }}">
-    <meta name="appointment-date" content="{{ \Carbon\Carbon::parse($appointment->appointment_date . ' ' . $appointment->start_time)->toIso8601String() }}">
+    <meta name="appointment-date" content="{{ \Carbon\Carbon::parse($appointment->start_time)->toIso8601String() }}">
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
           integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>


### PR DESCRIPTION
This commit simplifies how the appointment date and time are processed by using the `start_time` attribute as the single source for the full datetime.

The `getAppointmentDateAttribute` accessor in the `Appointment` model has been removed as it was unnecessarily formatting the date and adding complexity.

The appointment details view is updated to parse the full datetime directly from the `start_time` attribute, eliminating the need to concatenate separate date and time fields. This makes the code cleaner and less prone to errors.