### PR TITLE
feat: Set default appointment status to 'notconfirmed'

### DIFF
--- a/Backend/app/Services/AppointmentBookingService.php
+++ b/Backend/app/Services/AppointmentBookingService.php
@@ -106,7 +106,7 @@ class AppointmentBookingService
             'appointment_date' => $appointmentDate,
             'start_time' => $carbonStartTime->format('H:i:s'),
             'end_time' => $endTime,
-            'status' => 'confirmed',
+            'status' => 'notconfirmed',
             'notes' => $notes,
             'total_price' => $totalPrice,
             'total_duration' => $totalDuration,


### PR DESCRIPTION
Update the initial status of newly created appointments from 'confirmed' to 'notconfirmed'. This ensures that appointments are initially in a pending state, requiring explicit confirmation.