### PR TITLE
feat: Implement banner management system

### DIFF
--- a/Backend/app/Http/Controllers/Admin/BannerController.php
+++ b/Backend/app/Http/Controllers/Admin/BannerController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Banner;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class BannerController extends Controller
+{
+    public function index()
+    {
+        $banners = Banner::all();
+        return view('admin.banners.index', compact('banners'));
+    }
+
+    public function create()
+    {
+        return view('admin.banners.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'image' => 'required|image',
+            'link' => 'nullable|url',
+            'location' => 'required|in:home,dashboard',
+        ]);
+
+        $path = $request->file('image')->store('banners', 'public');
+
+        Banner::create([
+            'image' => $path,
+            'link' => $request->link,
+            'location' => $request->location,
+        ]);
+
+        return redirect()->route('admin.banners.index')->with('success', 'بنر با موفقیت ایجاد شد.');
+    }
+
+    public function edit(Banner $banner)
+    {
+        return view('admin.banners.edit', compact('banner'));
+    }
+
+    public function update(Request $request, Banner $banner)
+    {
+        $request->validate([
+            'image' => 'nullable|image',
+            'link' => 'nullable|url',
+            'location' => 'required|in:home,dashboard',
+        ]);
+
+        $data = $request->only(['link', 'location']);
+
+        if ($request->hasFile('image')) {
+            Storage::disk('public')->delete($banner->image);
+            $data['image'] = $request->file('image')->store('banners', 'public');
+        }
+
+        $banner->update($data);
+
+        return redirect()->route('admin.banners.index')->with('success', 'بنر با موفقیت ویرایش شد.');
+    }
+
+    public function destroy(Banner $banner)
+    {
+        Storage::disk('public')->delete($banner->image);
+        $banner->delete();
+
+        return redirect()->route('admin.banners.index')->with('success', 'بنر با موفقیت حذف شد.');
+    }
+}

--- a/Backend/app/Http/Controllers/Api/BannerController.php
+++ b/Backend/app/Http/Controllers/Api/BannerController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Banner;
+use Illuminate\Http\Request;
+
+class BannerController extends Controller
+{
+    public function index(Request $request)
+    {
+        $location = $request->query('location');
+
+        if ($location) {
+            $banners = Banner::where('location', $location)->get();
+        } else {
+            $banners = Banner::all();
+        }
+
+        return response()->json($banners);
+    }
+}

--- a/Backend/app/Http/Controllers/AuthController.php
+++ b/Backend/app/Http/Controllers/AuthController.php
@@ -397,11 +397,7 @@ class AuthController extends Controller
                     $userUpdateData['business_category_id'] = $salonData['business_category_id'];
                 }
                 if (isset($salonData['business_subcategory_ids'])) {
-                    $userUpdateData['business_subcategory_ids'] = $salonData['business_subcategory_ids'];
-                }
-
-                if (!empty($userUpdateData)) {
-                    $user->update($userUpdateData);
+                    $salon->businessSubcategories()->sync($salonData['business_subcategory_ids']);
                 }
             }
 

--- a/Backend/app/Models/Banner.php
+++ b/Backend/app/Models/Banner.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Banner extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'image',
+        'link',
+        'location',
+    ];
+}

--- a/Backend/database/migrations/2025_08_20_150359_create_banners_table.php
+++ b/Backend/database/migrations/2025_08_20_150359_create_banners_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('banners', function (Blueprint $table) {
+            $table->id();
+            $table->string('image');
+            $table->string('link')->nullable();
+            $table->string('location'); // 'home' or 'dashboard'
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('banners');
+    }
+};

--- a/Backend/resources/views/admin/banners/create.blade.php
+++ b/Backend/resources/views/admin/banners/create.blade.php
@@ -1,0 +1,51 @@
+@extends('admin.layouts.app')
+
+@section('title', 'ایجاد بنر جدید')
+
+@section('header')
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        ایجاد بنر جدید
+    </h2>
+@endsection
+
+@section('content')
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                @if($errors->any())
+                    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+                        <ul>
+                            @foreach($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                <form action="{{ route('admin.banners.store') }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    <div class="mb-4">
+                        <label for="image" class="block text-sm font-medium text-gray-700">تصویر</label>
+                        <input type="file" name="image" id="image" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" required>
+                    </div>
+                    <div class="mb-4">
+                        <label for="link" class="block text-sm font-medium text-gray-700">لینک</label>
+                        <input type="url" name="link" id="link" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="{{ old('link') }}">
+                    </div>
+                    <div class="mb-4">
+                        <label for="location" class="block text-sm font-medium text-gray-700">مکان</label>
+                        <select name="location" id="location" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" required>
+                            <option value="home">صفحه اصلی</option>
+                            <option value="dashboard">داشبورد</option>
+                        </select>
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            ذخیره
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Backend/resources/views/admin/banners/edit.blade.php
+++ b/Backend/resources/views/admin/banners/edit.blade.php
@@ -1,0 +1,53 @@
+@extends('admin.layouts.app')
+
+@section('title', 'ویرایش بنر')
+
+@section('header')
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        ویرایش بنر
+    </h2>
+@endsection
+
+@section('content')
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                @if($errors->any())
+                    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4" role="alert">
+                        <ul>
+                            @foreach($errors->all() as $error)
+                                <li>{{ $error }}</li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endif
+
+                <form action="{{ route('admin.banners.update', $banner) }}" method="POST" enctype="multipart/form-data">
+                    @csrf
+                    @method('PUT')
+                    <div class="mb-4">
+                        <label for="image" class="block text-sm font-medium text-gray-700">تصویر</label>
+                        <input type="file" name="image" id="image" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50">
+                        <img src="{{ asset('storage/' . $banner->image) }}" alt="Banner" class="mt-2 h-24 w-24 object-cover rounded-md">
+                    </div>
+                    <div class="mb-4">
+                        <label for="link" class="block text-sm font-medium text-gray-700">لینک</label>
+                        <input type="url" name="link" id="link" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" value="{{ old('link', $banner->link) }}">
+                    </div>
+                    <div class="mb-4">
+                        <label for="location" class="block text-sm font-medium text-gray-700">مکان</label>
+                        <select name="location" id="location" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50" required>
+                            <option value="home" {{ $banner->location == 'home' ? 'selected' : '' }}>صفحه اصلی</option>
+                            <option value="dashboard" {{ $banner->location == 'dashboard' ? 'selected' : '' }}>داشبورد</option>
+                        </select>
+                    </div>
+                    <div class="flex items-center justify-end mt-4">
+                        <button type="submit" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                            ذخیره
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Backend/resources/views/admin/banners/index.blade.php
+++ b/Backend/resources/views/admin/banners/index.blade.php
@@ -1,0 +1,62 @@
+@extends('admin.layouts.app')
+
+@section('title', 'مدیریت بنرها')
+
+@section('header')
+    <h2 class="font-semibold text-xl text-gray-800 leading-tight">
+        مدیریت بنرها
+    </h2>
+@endsection
+
+@section('content')
+    <div class="py-12">
+        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6">
+                <div class="flex justify-between items-center mb-4">
+                    <h3 class="text-lg font-medium text-gray-900">لیست بنرها</h3>
+                    <a href="{{ route('admin.banners.create') }}" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                        ایجاد بنر جدید
+                    </a>
+                </div>
+
+                @if(session('success'))
+                    <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4" role="alert">
+                        <span class="block sm:inline">{{ session('success') }}</span>
+                    </div>
+                @endif
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">تصویر</th>
+                                <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">لینک</th>
+                                <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">مکان</th>
+                                <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">عملیات</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @foreach($banners as $banner)
+                                <tr>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <img src="{{ asset('storage/' . $banner->image) }}" alt="Banner" class="h-16 w-16 object-cover rounded-md">
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $banner->link }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $banner->location }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                                        <a href="{{ route('admin.banners.edit', $banner) }}" class="text-indigo-600 hover:text-indigo-900 ml-2">ویرایش</a>
+                                        <form action="{{ route('admin.banners.destroy', $banner) }}" method="POST" class="inline-block">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600 hover:text-red-900" onclick="return confirm('آیا مطمئن هستید؟')">حذف</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/Backend/resources/views/admin/layouts/sidebar.blade.php
+++ b/Backend/resources/views/admin/layouts/sidebar.blade.php
@@ -50,6 +50,10 @@
             <i class="ri-file-line text-xl"></i>
             <span class="mr-4">فایل ها</span>
         </a>
+        <a href="{{ route('admin.banners.index') }}" class="flex items-center py-3 px-6 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.banners.*')) bg-gray-700 @endif">
+            <i class="ri-image-line text-xl"></i>
+            <span class="mr-4">مدیریت بنرها</span>
+        </a>
         <div x-data="{ open: {{ request()->routeIs('admin.how-introduced.*') || request()->routeIs('admin.professions.*') || request()->routeIs('admin.customer-groups.*') ? 'true' : 'false' }} }">
             <a @click="open = !open" href="#" class="flex items-center justify-between py-3 px-6 transition duration-200 hover:bg-gray-700 cursor-pointer">
                 <div class="flex items-center">

--- a/Backend/routes/admin.php
+++ b/Backend/routes/admin.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Admin\HowIntroducedController;
 use App\Http\Controllers\Admin\ProfessionController; 
 use App\Http\Controllers\Admin\CustomerGroupController;
 use App\Http\Controllers\Admin\FileController;
+use App\Http\Controllers\Admin\BannerController;
 use App\Http\Controllers\ManualSmsController;
 use App\Http\Middleware\SuperAdminMiddleware;
 use Illuminate\Support\Facades\Route;
@@ -50,4 +51,7 @@ Route::middleware(['auth:web', SuperAdminMiddleware::class])->name('admin.')->gr
 
     // Files
     Route::resource('files', FileController::class);
+
+    // Banners
+    Route::resource('banners', BannerController::class);
 });

--- a/Backend/routes/api.php
+++ b/Backend/routes/api.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\SmsTransactionController;
 use App\Http\Controllers\SmsCampaignController;
 use App\Http\Controllers\Api\AppController;
 use App\Http\Controllers\Api\NotificationController;
+use App\Http\Controllers\Api\BannerController as ApiBannerController;
 use App\Http\Controllers\SatisfactionController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -184,6 +185,8 @@ Route::get('/app-history', [AppController::class, 'latestHistory']);
 Route::get('/staff/{staffId}/appointments', [AppController::class, 'getStaffAppointments'])->whereNumber('staffId');
 
 Route::get('/notifications', [NotificationController::class, 'index']);
+
+Route::get('/banners', [ApiBannerController::class, 'index']);
 
 Route::middleware('auth:api')->post('/appointments/{appointment}/send-satisfaction-survey', [SatisfactionController::class, 'sendSurvey'])->name('api.appointments.send-satisfaction-survey');
 


### PR DESCRIPTION
Adds full CRUD functionality for banners in the admin panel, including a new model, migration, and dedicated controllers. Exposes a public API endpoint for retrieving banners. Updates the admin sidebar with a link to the new banner management section. Refactors salon business subcategory update logic in `AuthController` to use `sync` for better relationship management.