### PR TITLE
Adjust email column position in salons table migration

### DIFF
--- a/Backend/database/migrations/2025_08_24_121341_add_email_to_salons_table.php
+++ b/Backend/database/migrations/2025_08_24_121341_add_email_to_salons_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('salons', function (Blueprint $table) {
-            $table->string('email')->nullable()->unique()->after('mobile');
+            $table->string('email')->nullable()->unique()->after('name');
         });
     }
 


### PR DESCRIPTION
Move the `email` column to appear after the `name` column instead of `mobile` in the `salons` table migration.