### PR TITLE
feat: Add SMS balance accessor to Salon model and fix Jalali date class

### DIFF
--- a/Backend/app/Models/Salon.php
+++ b/Backend/app/Models/Salon.php
@@ -207,6 +207,16 @@ class Salon extends Model
     }
 
     /**
+     * Get the SMS balance attribute for the salon.
+     *
+     * @return int
+     */
+    public function getSmsBalanceAttribute()
+    {
+        return $this->smsBalance->balance ?? 0;
+    }
+
+    /**
      * Get the SMS transactions for the salon.
      */
     public function smsTransactions()

--- a/Backend/resources/views/admin/bulk_sms_gift/index.blade.php
+++ b/Backend/resources/views/admin/bulk_sms_gift/index.blade.php
@@ -182,7 +182,7 @@
                                 {{ $salon->smsBalance->balance ?? 0 }}
                             </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                                {{ $salon->lastSmsPurchaseDate ? \Morilog\Jalali\Jalali::fromCarbon($salon->lastSmsPurchaseDate)->format('Y/m/d') : 'تاکنون خرید نکرده' }}
+                                        {{ $salon->lastSmsPurchaseDate ? \Morilog\Jalali\Jalalian::fromCarbon($salon->lastSmsPurchaseDate)->format('Y/m/d') : 'تاکنون خرید نکرده' }}
                             </td>
                         </tr>
                     @empty


### PR DESCRIPTION
- Introduce `getSmsBalanceAttribute` to the `Salon` model, providing a convenient way to access the salon's SMS balance via `$salon->sms_balance`.
- Correct the `Jalali` class name to `Jalalian` in the bulk SMS gift index view for proper date conversion.