### PR TITLE
Rename SMS balance field to 'balance'

### DIFF
--- a/Backend/app/Http/Controllers/Admin/AdminSalonController.php
+++ b/Backend/app/Http/Controllers/Admin/AdminSalonController.php
@@ -249,8 +249,8 @@ class AdminSalonController extends Controller
 
         foreach ($salons as $salon) {
             // Ensure salon has an SMS balance record, create if not
-            $smsBalance = $salon->smsBalance()->firstOrCreate(['salon_id' => $salon->id], ['current_sms_count' => 0]);
-            $smsBalance->current_sms_count += $amount;
+            $smsBalance = $salon->smsBalance()->firstOrCreate(['salon_id' => $salon->id], ['balance' => 0]);
+            $smsBalance->balance += $amount;
             $smsBalance->save();
 
             // Record transaction
@@ -303,9 +303,9 @@ class AdminSalonController extends Controller
 
         $smsBalance = $salon->smsBalance()->firstOrCreate(
             ['salon_id' => $salon->id],
-            ['current_sms_count' => 0]
+            ['balance' => 0]
         );
-        $smsBalance->current_sms_count += $request->amount;
+        $smsBalance->balance += $request->amount;
         $smsBalance->save();
 
         // Reload the salon and its smsBalance to ensure fresh data

--- a/Backend/app/Http/Controllers/Api/AppController.php
+++ b/Backend/app/Http/Controllers/Api/AppController.php
@@ -39,7 +39,7 @@ class AppController extends Controller
 
         if ($salon) {
             Log::info('AppController@getSmsBalance: Active Salon found. Salon ID: ' . $salon->id . ', Is Active: ' . (bool) $salon->is_active);
-            $balance = $salon->smsBalance ? $salon->smsBalance->current_sms_count : 0;
+            $balance = $salon->smsBalance ? $salon->smsBalance->balance : 0;
             Log::info('AppController@getSmsBalance: Salon SMS Balance: ' . $balance);
 
             return response()->json([

--- a/Backend/app/Http/Controllers/AuthController.php
+++ b/Backend/app/Http/Controllers/AuthController.php
@@ -321,7 +321,7 @@ class AuthController extends Controller
 
         $responseData = $user->toArray();
         if ($user->activeSalon && $user->activeSalon->smsBalance) {
-            $responseData['active_salon']['sms_balance'] = $user->activeSalon->smsBalance->current_sms_count;
+            $responseData['active_salon']['sms_balance'] = $user->activeSalon->smsBalance->balance;
         } else {
             $responseData['active_salon']['sms_balance'] = 0; // Default to 0 if no active salon or no smsBalance
         }

--- a/Backend/app/Http/Controllers/ZarinpalController.php
+++ b/Backend/app/Http/Controllers/ZarinpalController.php
@@ -159,13 +159,13 @@ class ZarinpalController extends Controller
             if ($user->active_salon_id) {
                 $salonSmsBalance = \App\Models\SalonSmsBalance::firstOrCreate(
                     ['salon_id' => $user->active_salon_id],
-                    ['current_sms_count' => 0]
+                    ['balance' => 0]
                 );
-                $salonSmsBalance->increment('current_sms_count', $transaction->sms_count);
+                $salonSmsBalance->increment('balance', $transaction->sms_count);
 
                 Log::info('Salon SMS balance updated successfully after Zarinpal purchase.', [
                     'salon_id' => $user->active_salon_id,
-                    'new_salon_balance' => $salonSmsBalance->current_sms_count,
+                    'new_salon_balance' => $salonSmsBalance->balance,
                     'transaction_id' => $transaction->id,
                 ]);
             }
@@ -175,7 +175,7 @@ class ZarinpalController extends Controller
                 'message' => 'پرداخت با موفقیت تایید شد.',
                 'purchased_sms' => $transaction->sms_count,
                 'user_total_balance' => $userBalance->balance, // Renamed for clarity
-                'salon_total_balance' => $user->active_salon_id ? $salonSmsBalance->current_sms_count : 0, // Include salon balance
+                'salon_total_balance' => $user->active_salon_id ? $salonSmsBalance->balance : 0, // Include salon balance
                 'reference_id' => $receipt->getReferenceId(),
             ]);
         } catch (InvalidPaymentException $e) {

--- a/Backend/app/Models/SalonSmsBalance.php
+++ b/Backend/app/Models/SalonSmsBalance.php
@@ -11,7 +11,7 @@ class SalonSmsBalance extends Model
 
     protected $fillable = [
         'salon_id',
-        'current_sms_count',
+        'balance',
     ];
 
     public function salon()

--- a/Backend/resources/views/admin/salons/show.blade.php
+++ b/Backend/resources/views/admin/salons/show.blade.php
@@ -43,7 +43,7 @@
                             ثبت نشده
                         @endforelse
                     </p>
-                    <p><strong>اعتبار پیامک:</strong> {{ $salon->smsBalance->current_sms_count ?? 0 }}</p>
+                    <p><strong>اعتبار پیامک:</strong> {{ $salon->smsBalance->balance ?? 0 }}</p>
                 </div>
             </div>
             <div>


### PR DESCRIPTION
Renamed the `current_sms_count` column in the `SalonSmsBalance` model to `balance` and updated all corresponding references in controllers, API endpoints, and views. This change improves clarity and consistency in terminology.