### PR TITLE
feat: Enhance profile validation for password and images

### DIFF
--- a/Backend/app/Http/Requests/CompleteProfileRequest.php
+++ b/Backend/app/Http/Requests/CompleteProfileRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rules\Password;
+use Illuminate\Support\Facades\Auth;
 class CompleteProfileRequest extends FormRequest
 {
     /**
@@ -21,12 +22,12 @@ class CompleteProfileRequest extends FormRequest
      *
      * @return array
      */
-    public function rules()
+    public function rules(): array
     {
         return [
             'name' => 'required|string|max:255',
-            'password' => ['required', 'string', 'min:8', 'confirmed'],
-            'avatar' => 'nullable|image|max:2048', // Changed from 'image'
+            'password' => ['required', 'string', 'confirmed', Password::min(8)->letters()->numbers()],
+            'avatar' => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
             'business_name' => 'required|string|max:255',
             'business_category_id' => 'required|exists:business_categories,id',
             'business_subcategory_ids' => 'nullable|array',
@@ -41,7 +42,7 @@ class CompleteProfileRequest extends FormRequest
             'website'                   => 'nullable|string|max:255',
             'latitude'                  => 'nullable|numeric|between:-90,90',
             'longitude'                 => 'nullable|numeric|between:-180,180',
-            'image'                     => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048', // Changed from 'salon_image'
+            'image'                     => 'nullable|image|mimes:jpeg,png,jpg,gif,webp|max:2048',
             'whatsapp'                  => 'nullable|string|max:255',
         ];
     }
@@ -55,11 +56,17 @@ class CompleteProfileRequest extends FormRequest
     {
         return [
             'name.required' => 'نام الزامی است',
-            'password.required' => 'رمز عبور الزامی است',
-            'password.min' => 'رمز عبور باید حداقل ۸ کاراکتر باشد',
-            'password.confirmed' => 'تکرار رمز عبور مطابقت ندارد',
-            'image.image' => 'فایل آپلود شده باید تصویر باشد',
-            'image.max' => 'حداکثر حجم تصویر ۲ مگابایت است',
+            'password.required' => 'رمز عبور الزامی است.',
+            'password.min' => 'رمز عبور باید حداقل ۸ کاراکتر باشد.',
+            'password.letters' => 'رمز عبور باید حداقل شامل یک حرف انگلیسی باشد.',
+            'password.numbers' => 'رمز عبور باید حداقل شامل یک عدد باشد.',
+            'password.confirmed' => 'تکرار رمز عبور مطابقت ندارد.',
+            'avatar.image' => 'فایل آپلود شده برای آواتار باید از نوع تصویر باشد.',
+            'avatar.mimes' => 'فرمت تصویر آواتار باید jpeg, png, jpg, gif یا webp باشد.',
+            'avatar.max' => 'حداکثر حجم تصویر آواتار می‌تواند ۲ مگابایت باشد.',
+            'image.image' => 'فایل آپلود شده برای تصویر سالن باید از نوع تصویر باشد.',
+            'image.mimes' => 'فرمت تصویر سالن باید jpeg, png, jpg, gif یا webp باشد.',
+            'image.max' => 'حداکثر حجم تصویر سالن می‌تواند ۲ مگابایت باشد.',
             'business_name.required' => 'وارد کردن نام کسب و کار (سالن) الزامی است.',
             'business_category_id.required' => 'انتخاب دسته‌بندی کسب و کار الزامی است.',
             'business_category_id.exists' => 'دسته‌بندی کسب و کار انتخاب شده معتبر نیست.',

--- a/Backend/app/Http/Requests/UpdateProfileRequest.php
+++ b/Backend/app/Http/Requests/UpdateProfileRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
 
 class UpdateProfileRequest extends FormRequest
 {
@@ -34,7 +35,7 @@ class UpdateProfileRequest extends FormRequest
             'user.name' => 'sometimes|string|max:255',
             'user.email' => ['nullable', 'email', 'max:255', Rule::unique('users', 'email')->ignore($user->id)],
             'user.current_password' => 'nullable|required_with:user.new_password|string',
-            'user.new_password' => 'nullable|string|min:8|confirmed',
+            'user.new_password' => ['nullable', 'string', 'confirmed', Password::min(8)->letters()->numbers()],
             'user.gender' => 'sometimes|nullable|in:male,female,other',
             'user.date_of_birth' => 'sometimes|nullable|string', // Will be parsed as Jalali date in controller
 


### PR DESCRIPTION
Refine validation rules for `CompleteProfileRequest` and `UpdateProfileRequest`:
- Strengthen password validation to require at least one letter and one number, in addition to a minimum length of 8 characters.
- Add explicit MIME type validation (jpeg, png, jpg, gif, webp) for `avatar` and `image` fields.
- Improve clarity and specificity of validation error messages for password and image fields.
- Add return type declaration for the `rules()` method.