### PR TITLE
Refine subcategory ID detection in profile update request

### DIFF
--- a/Backend/app/Http/Requests/UpdateProfileRequest.php
+++ b/Backend/app/Http/Requests/UpdateProfileRequest.php
@@ -15,7 +15,9 @@ class UpdateProfileRequest extends FormRequest
 
     protected function prepareForValidation()
     {
-        if ($this->has('salon.business_subcategory_ids')) {
+        // Check if any input related to salon.business_subcategory_ids is present
+        // This handles cases where it's sent as salon[business_subcategory_ids][]
+        if ($this->hasAny(['salon.business_subcategory_ids', 'salon.business_subcategory_ids.0'])) {
             $this->merge([
                 'salon' => array_merge($this->input('salon', []), [
                     'business_subcategory_ids' => $this->input('salon.business_subcategory_ids', []),


### PR DESCRIPTION
Update `UpdateProfileRequest` to correctly detect `business_subcategory_ids`. This change adds a check for `salon.business_subcategory_ids.0` to the `prepareForValidation` method, ensuring subcategory IDs are properly merged for validation when sent as an array of inputs (e.g., `salon[business_subcategory_ids][]`).