### PR TITLE
feat: Add daily appointment list API and relax CORS policy

### DIFF
--- a/Backend/app/Http/Controllers/AppointmentReportController.php
+++ b/Backend/app/Http/Controllers/AppointmentReportController.php
@@ -255,7 +255,31 @@ class AppointmentReportController extends Controller
         ]);
     }
 
-    // 4. Detailed Reports
+    // 4. Daily Appointments List (for debugging/verification)
+    public function getDailyAppointmentsList(Request $request, Salon $salon)
+    {
+        $this->checkAccess($salon);
+
+        $request->validate([
+            'date' => 'required|jdate:Y-m-d',
+        ]);
+
+        $jalaliDate = $request->input('date');
+        $date = Jalalian::fromFormat('Y-m-d', $jalaliDate)->toCarbon();
+
+        $appointments = Appointment::where('salon_id', $salon->id)
+            ->whereDate('appointment_date', $date)
+            ->select('id', 'customer_id', 'staff_id', 'appointment_date', 'start_time', 'end_time', 'status', 'total_price')
+            ->with(['customer:id,first_name,last_name', 'staff:id,first_name,last_name'])
+            ->get();
+
+        return response()->json([
+            'date' => $jalaliDate,
+            'appointments' => $appointments,
+        ]);
+    }
+
+    // 5. Detailed Reports
     public function getDetailedReports(Request $request, Salon $salon)
     {
         $this->checkAccess($salon);

--- a/Backend/app/Http/Middleware/CorsMiddleware.php
+++ b/Backend/app/Http/Middleware/CorsMiddleware.php
@@ -17,7 +17,10 @@ class CorsMiddleware
     {
         $response = $next($request);
 
-        $response->headers->set('Access-Control-Allow-Origin', 'https://ziboxcrm.ir');
+        $allowedOrigins = ['https://ziboxcrm.ir', 'https://api.ziboxcrm.ir'];
+        $origin = $request->headers->get('Origin');
+
+        $response->headers->set('Access-Control-Allow-Origin', '*');
         $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
         $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
         $response->headers->set('Access-Control-Allow-Credentials', 'true');

--- a/Backend/routes/api.php
+++ b/Backend/routes/api.php
@@ -134,6 +134,7 @@ Route::middleware('auth:api')->group(function () {
                 Route::get('analytical', [AppointmentReportController::class, 'getAnalyticalReports'])->name('analytical');
                 Route::get('detailed', [AppointmentReportController::class, 'getDetailedReports'])->name('detailed');
                 Route::get('daily-summary', [AppointmentReportController::class, 'getDailySummaryReport'])->name('daily_summary');
+                Route::get('daily-list', [AppointmentReportController::class, 'getDailyAppointmentsList'])->name('daily_list');
             });
 
             Route::prefix('sms-account')->name('sms_account.')->group(function () {


### PR DESCRIPTION
Implement a new API endpoint `/api/reports/daily-list` to retrieve a detailed list of appointments for a specified date, including customer and staff information. This endpoint is useful for debugging and verification.

Update the `CorsMiddleware` to set `Access-Control-Allow-Origin` to `*`, allowing requests from all origins for increased flexibility.