### PR TITLE
Refactor: Enforce specific CORS origins and credentials

### DIFF
--- a/Backend/app/Http/Middleware/CorsMiddleware.php
+++ b/Backend/app/Http/Middleware/CorsMiddleware.php
@@ -17,13 +17,20 @@ class CorsMiddleware
     {
         $response = $next($request);
 
-        $allowedOrigins = ['https://ziboxcrm.ir', 'https://api.ziboxcrm.ir'];
+        $allowedOrigins = [
+            'https://ziboxcrm.ir',
+            'https://api.ziboxcrm.ir',
+        ];
+
         $origin = $request->headers->get('Origin');
 
-        $response->headers->set('Access-Control-Allow-Origin', '*');
+        if ($origin && in_array($origin, $allowedOrigins)) {
+            $response->headers->set('Access-Control-Allow-Origin', $origin);
+            $response->headers->set('Access-Control-Allow-Credentials', 'true');
+        }
+
         $response->headers->set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
         $response->headers->set('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
-        $response->headers->set('Access-Control-Allow-Credentials', 'true');
 
         return $response;
     }


### PR DESCRIPTION
Update the CORS middleware to restrict 'Access-Control-Allow-Origin' to a predefined list of trusted domains instead of allowing all ('*'). Additionally, 'Access-Control-Allow-Credentials' is now only set when the request origin matches an allowed domain, enhancing security.