### PR TITLE
Refactor SMS package boolean input and update FK constraint

### DIFF
--- a/Backend/app/Http/Controllers/Admin/SmsPackageController.php
+++ b/Backend/app/Http/Controllers/Admin/SmsPackageController.php
@@ -40,7 +40,7 @@ class SmsPackageController extends Controller
         ]);
 
         $data = $request->only(['name', 'sms_count', 'price', 'discount_price']);
-        $data['is_active'] = $request->has('is_active');
+        $data['is_active'] = $request->boolean('is_active');
 
         SmsPackage::create($data);
 
@@ -73,7 +73,7 @@ class SmsPackageController extends Controller
         Log::info('SmsPackage validation passed.');
 
         $data = $request->only(['name', 'sms_count', 'price', 'discount_price']);
-        $data['is_active'] = $request->has('is_active');
+        $data['is_active'] = $request->boolean('is_active');
 
         Log::info('SmsPackage data prepared for update.', ['prepared_data' => $data]);
         Log::info('SmsPackage before update.', ['smsPackage_before' => $smsPackage->toArray()]);

--- a/Backend/database/migrations/2025_07_24_164158_add_payment_details_to_sms_transactions_table.php
+++ b/Backend/database/migrations/2025_07_24_164158_add_payment_details_to_sms_transactions_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('sms_transactions', function (Blueprint $table) {
-            $table->foreignId('sms_package_id')->nullable()->constrained('sms_packages')->after('salon_id');
+            $table->foreignId('sms_package_id')->nullable()->constrained('sms_packages')->onDelete('set null')->after('salon_id');
             $table->decimal('amount', 10, 2)->nullable()->after('sms_package_id');
             $table->string('transaction_id')->nullable()->after('amount');
         });


### PR DESCRIPTION
Update `SmsPackageController` to use `request->boolean('is_active')` for parsing the `is_active` field, ensuring more robust boolean conversion. Add `onDelete('set null')` to the `sms_package_id` foreign key in the `sms_transactions` table, allowing SMS packages to be deleted without restricting related transactions.