### PR TITLE
feat: Safely delete SMS packages and disassociate transactions

### DIFF
--- a/Backend/app/Http/Controllers/Admin/SmsPackageController.php
+++ b/Backend/app/Http/Controllers/Admin/SmsPackageController.php
@@ -93,7 +93,15 @@ class SmsPackageController extends Controller
      */
     public function destroy(SmsPackage $smsPackage)
     {
-        $smsPackage->delete();
-        return redirect()->route('admin.sms-packages.index')->with('success', 'پکیج با موفقیت حذف شد.');
+        try {
+            // Disassociate related SmsTransactions by setting sms_package_id to NULL
+            $smsPackage->smsTransactions()->update(['sms_package_id' => null]);
+
+            $smsPackage->delete();
+            return redirect()->route('admin.sms-packages.index')->with('success', 'پکیج با موفقیت حذف شد.');
+        } catch (\Exception $e) {
+            Log::error('Error deleting SmsPackage: ' . $e->getMessage(), ['smsPackage_id' => $smsPackage->id, 'exception' => $e]);
+            return redirect()->back()->with('error', 'خطا در حذف پکیج پیامک: ' . $e->getMessage());
+        }
     }
 }

--- a/Backend/app/Models/SmsPackage.php
+++ b/Backend/app/Models/SmsPackage.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class SmsPackage extends Model
 {
@@ -13,6 +14,14 @@ class SmsPackage extends Model
         'discount_price',
         'is_active',
     ];
+
+    /**
+     * Get the SMS transactions for the SMS package.
+     */
+    public function smsTransactions(): HasMany
+    {
+        return $this->hasMany(SmsTransaction::class);
+    }
 
     protected $casts = [
         'price' => 'integer',


### PR DESCRIPTION
- Before deleting an `SmsPackage`, disassociate related `SmsTransaction` records by setting their `sms_package_id` to `null`. This prevents foreign key constraint issues.
- Add `smsTransactions` HasMany relationship to the `SmsPackage` model.
- Implement error handling and logging for the deletion process.