### PR TITLE
Feat: Add customer restore on import/create; implement satisfaction survey

### DIFF
--- a/Backend/app/Jobs/SendAppointmentReminderSms.php
+++ b/Backend/app/Jobs/SendAppointmentReminderSms.php
@@ -54,13 +54,8 @@ class SendAppointmentReminderSms implements ShouldQueue
             return;
         }
 
-        $smsResult = $smsService->sendAppointmentReminder($customer, $appointment, $this->salon);
-
-        if ($smsResult['status'] === 'success') {
-            Log::info("Successfully sent reminder SMS for appointment {$appointment->id}.");
-        } else {
-            Log::error("Failed to send reminder SMS for appointment {$appointment->id}: " . $smsResult['message']);
-            $appointment->update(['reminder_sms_status' => 'failed']);
-        }
+        $smsService->sendAppointmentReminder($customer, $appointment, $this->salon);
+        // The SmsService now handles updating the appointment's SMS status.
+        Log::info("Reminder SMS sending process initiated for appointment {$appointment->id}. Status updates handled by SmsService.");
     }
 }

--- a/Backend/app/Services/SmsService.php
+++ b/Backend/app/Services/SmsService.php
@@ -184,7 +184,7 @@ class SmsService
     public function sendOtp(string $receptor, string $otpCode): bool
     {
         // As per the request for Android automatic OTP verification.
-        $appName = 'بیوتی سی آر ام';
+        $appName = 'زیباکس';
         $appSignature = '0iHp5lSm3eN'; // This should be stored securely, e.g., in config/app.php
 
         $message = "<#>\n" .

--- a/Backend/resources/views/appointments/details.blade.php
+++ b/Backend/resources/views/appointments/details.blade.php
@@ -197,12 +197,10 @@
         <div class="text-zinc-400 text-sm font-medium border  rounded-lg py-2 px-4">
             نســخــه {{ str_replace($englishDigits, $persianDigits, '1.0.1') }}</div>
       <div class="flex flex-col justify-end">
-          <div>
-              <span class="text-teal-900 text-2xl font-black">بیوتی </span>
-              <span class="text-orange-400 text-2xl font-black">سی</span>
-              <span class="text-teal-900 text-2xl font-black"> آر ام</span>
-          </div>
-          <div class="text-zinc-400 text-[10px] font-normal ">اپلیکیشن مدیریت مشتریان</div>
+<div class="w-28 h-12 relative">
+    <div class="left-0 top-0 absolute justify-start"><span class="text-zinc-900 text-2xl font-black font-['Peyda']">زیـ </span><span class="text-orange-400 text-2xl font-black font-['Peyda']">بـــاکــس</span></div>
+    <div class="left-[5px] top-[34px] absolute justify-start text-zinc-400 text-[10px] font-normal font-['Peyda']">اپلیکیشن مدیریت مشتریان</div>
+</div>
       </div>
     </footer>
 </main>

--- a/Backend/resources/views/appointments/satisfaction.blade.php
+++ b/Backend/resources/views/appointments/satisfaction.blade.php
@@ -91,12 +91,11 @@
         <div class="text-zinc-400 text-sm font-medium border  rounded-lg py-2 px-4">
             نســخــه {{ str_replace($englishDigits, $persianDigits, '1.0.1') }}</div>
         <div class="flex flex-col justify-end">
-            <div>
-                <span class="text-teal-900 text-2xl font-black">بیوتی </span>
-                <span class="text-orange-400 text-2xl font-black">سی</span>
-                <span class="text-teal-900 text-2xl font-black"> آر ام</span>
-            </div>
-            <div class="text-zinc-400 text-[10px] font-normal ">اپلیکیشن مدیریت مشتریان</div>
+<div class="w-28 h-12 relative">
+    <div class="left-0 top-0 absolute justify-start"><span class="text-zinc-900 text-2xl font-black font-['Peyda']">زیـ </span><span class="text-orange-400 text-2xl font-black font-['Peyda']">بـــاکــس</span></div>
+    <div class="left-[5px] top-[34px] absolute justify-start text-zinc-400 text-[10px] font-normal font-['Peyda']">اپلیکیشن مدیریت مشتریان</div>
+</div>
+
         </div>
     </footer>
 </main>


### PR DESCRIPTION
*   **Customer Management:**
    *   Update customer creation and import processes to check for soft-deleted customers by phone number.
    *   Restore and update soft-deleted customers if found, preventing duplicate entries.
    *   Return a conflict error if an active customer with the same phone number already exists during creation.
*   **Satisfaction Survey:**
    *   Introduce a new feature to send satisfaction survey SMS messages for appointments.
    *   Add a button to the appointment details page to trigger the survey SMS.
    *   Create a dedicated Blade view for customers to submit their survey responses.
*   **SMS Service Refactoring:**
    *   Refactor `SmsService` from static methods to use instance methods and dependency injection.
    *   Update SMS-sending jobs (`SendAppointmentReminderSms`, `SendSatisfactionSurveySms`) to utilize the refactored service.
    *   Add logging for SMS sending operations to improve traceability.