### PR TITLE
feat: Automate past appointment cancellation and refine admin SMS menu

### DIFF
--- a/Backend/app/Console/Commands/CancelPastAppointments.php
+++ b/Backend/app/Console/Commands/CancelPastAppointments.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class CancelPastAppointments extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'appointments:cancel-past';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Cancel past appointments that are still active';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $now = now();
+        $appointments = \App\Models\Appointment::whereIn('status', ['confirmed', 'pending_confirmation'])
+            ->where('appointment_date', '<', $now)
+            ->get();
+
+        foreach ($appointments as $appointment) {
+            $appointment->update(['status' => 'canceled']);
+        }
+
+        $this->info(count($appointments) . ' past appointments have been canceled.');
+    }
+}

--- a/Backend/app/Console/kernel.php
+++ b/Backend/app/Console/kernel.php
@@ -30,6 +30,9 @@ class Kernel extends ConsoleKernel
 
         // بررسی وضعیت پیامک ها
         $schedule->job(\App\Jobs\CheckSmsStatus::class)->everyFiveMinutes();
+
+        // Cancel past appointments
+        $schedule->command('appointments:cancel-past')->daily();
     }
 
     /**

--- a/Backend/app/Http/Controllers/AuthController.php
+++ b/Backend/app/Http/Controllers/AuthController.php
@@ -308,12 +308,30 @@ class AuthController extends Controller
 
         // Eager load counts for the active salon if it exists
         if ($user->activeSalon) {
-            $user->activeSalon->loadCount(['customers', 'appointments']);
+            $user->activeSalon->loadCount([
+                'customers',
+                'appointments as total_appointments_count',
+                'appointments as active_appointments_count' => function ($query) {
+                    $query->whereIn('status', ['confirmed', 'pending_confirmation']);
+                },
+                'appointments as canceled_appointments_count' => function ($query) {
+                    $query->where('status', 'canceled');
+                }
+            ]);
         }
 
         // Also load counts for all salons
         $user->salons->each(function ($salon) {
-            $salon->loadCount(['customers', 'appointments']);
+            $salon->loadCount([
+                'customers',
+                'appointments as total_appointments_count',
+                'appointments as active_appointments_count' => function ($query) {
+                    $query->whereIn('status', ['confirmed', 'pending_confirmation']);
+                },
+                'appointments as canceled_appointments_count' => function ($query) {
+                    $query->where('status', 'canceled');
+                }
+            ]);
         });
 
         $responseData = $user->toArray();

--- a/Backend/app/Http/Controllers/CustomerController.php
+++ b/Backend/app/Http/Controllers/CustomerController.php
@@ -156,11 +156,11 @@ class CustomerController extends Controller
         $this->authorize('delete', $customer);
 
         try {
-            // Find active appointments and cancel them
-            $customer->appointments()->whereIn('status', ['confirmed', 'pending_confirmation'])->update(['status' => 'canceled']);
+            // Cancel future appointments for the customer
+            $customer->appointments()->where('appointment_date', '>=', now())->update(['status' => 'canceled']);
 
             $customer->delete();
-            return response()->json(['message' => 'مشتری و نوبت‌های فعال او با موفقیت لغو شدند.'], 200);
+            return response()->json(['message' => 'مشتری و نوبت‌های آینده او با موفقیت لغو شدند.'], 200);
         } catch (\Exception $e) {
             Log::error('خطا در حذف مشتری: ' . $e->getMessage());
             return response()->json(['message' => 'خطا در حذف مشتری.'], 500);
@@ -183,11 +183,12 @@ class CustomerController extends Controller
             ->get();
 
         foreach ($customers as $customer) {
-            $customer->appointments()->whereIn('status', ['confirmed', 'pending_confirmation'])->update(['status' => 'canceled']);
+            // Cancel future appointments for the customer
+            $customer->appointments()->where('appointment_date', '>=', now())->update(['status' => 'canceled']);
             $customer->delete();
         }
 
-        return response()->json(['message' => count($customers) . ' مشتری و نوبت‌های فعال آن‌ها با موفقیت لغو شدند.']);
+        return response()->json(['message' => count($customers) . ' مشتری و نوبت‌های آینده آن‌ها با موفقیت لغو شدند.']);
     }
 
     public function importExcel(ImportCustomersExcelRequest $request, Salon $salon)

--- a/Backend/app/Http/Resources/AppointmentResource.php
+++ b/Backend/app/Http/Resources/AppointmentResource.php
@@ -52,13 +52,13 @@ class AppointmentResource extends JsonResource
             'satisfaction_sms_message_id' => $this->satisfaction_sms_message_id,
             'jalalidate' => Jalalian::fromCarbon($this->appointment_date)->format('Y/m/d'),
             'customer' => [
-                'id' => $this->customer->id,
-                'name' => $this->customer->name,
-                'phone_number' => $this->customer->phone_number,
+                'id' => optional($this->customer)->id,
+                'name' => optional($this->customer)->name,
+                'phone_number' => optional($this->customer)->phone_number,
             ],
             'staff' => [
-                'id' => $this->staff->id,
-                'full_name' => $this->staff->full_name,
+                'id' => optional($this->staff)->id,
+                'full_name' => optional($this->staff)->full_name,
             ],
             'services' => ServiceResource::collection($this->whenLoaded('services')),
         ];

--- a/Backend/package-lock.json
+++ b/Backend/package-lock.json
@@ -8,6 +8,7 @@
         "alpinejs": "^3.14.9",
         "bootstrap": "^5.3.7",
         "chart.js": "^4.5.0",
+        "jquery": "^3.7.1",
         "leaflet": "^1.9.4",
         "persian-date": "^1.1.0",
         "persian-datepicker": "^1.2.0",
@@ -21,7 +22,8 @@
         "laravel-vite-plugin": "^2.0.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^3.4.17",
-        "vite": "^7.0.6"
+        "vite": "^7.0.6",
+        "vite-plugin-static-copy": "^3.1.2"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2086,6 +2088,21 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2376,6 +2393,19 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/laravel-vite-plugin": {
       "version": "2.0.0",
@@ -2874,6 +2904,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -3636,6 +3679,16 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -3758,6 +3811,26 @@
       "dependencies": {
         "picocolors": "^1.0.0",
         "picomatch": "^2.3.1"
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.1.2.tgz",
+      "integrity": "sha512-aVmYOzptLVOI2b1jL+cmkF7O6uhRv1u5fvOkQgbohWZp2CbR22kn9ZqkCUIt9umKF7UhdbsEpshn1rf4720QFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.6.0",
+        "fs-extra": "^11.3.0",
+        "p-map": "^7.0.3",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.14"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/Backend/package.json
+++ b/Backend/package.json
@@ -13,12 +13,14 @@
     "laravel-vite-plugin": "^2.0.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "vite": "^7.0.6"
+    "vite": "^7.0.6",
+    "vite-plugin-static-copy": "^3.1.2"
   },
   "dependencies": {
     "alpinejs": "^3.14.9",
     "bootstrap": "^5.3.7",
     "chart.js": "^4.5.0",
+    "jquery": "^3.7.1",
     "leaflet": "^1.9.4",
     "persian-date": "^1.1.0",
     "persian-datepicker": "^1.2.0",

--- a/Backend/resources/js/app.js
+++ b/Backend/resources/js/app.js
@@ -1,7 +1,21 @@
 import './bootstrap';
 
 import Alpine from 'alpinejs';
+import 'remixicon/fonts/remixicon.css';
+import 'leaflet/dist/leaflet.css';
+import 'persian-datepicker/dist/css/persian-datepicker.min.css';
+
+import L from 'leaflet';
+import 'persian-date/dist/persian-date.min.js';
+import 'persian-datepicker/dist/js/persian-datepicker.min.js';
+
 window.Alpine = Alpine;
+window.L = L;
+
+document.addEventListener('alpine:init', () => {
+    // Alpine.js is ready
+});
+
 Alpine.start();
 
 import Chart from 'chart.js/auto';

--- a/Backend/resources/views/admin/layouts/app.blade.php
+++ b/Backend/resources/views/admin/layouts/app.blade.php
@@ -11,15 +11,10 @@
     <link rel="preconnect" href="https://fonts.bunny.net">
     <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
-    <!-- Icons -->
-    <link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet">
-
-    <!-- Leaflet CSS -->
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <!-- Scripts -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
 
     <!-- Styles -->
-    <link rel="stylesheet" href="https://unpkg.com/persian-datepicker/dist/css/persian-datepicker.min.css"/>
     @vite(['resources/css/app.css', 'resources/js/app.js'])
     <style>
         /* Custom button styles */
@@ -61,12 +56,6 @@
             </main>
         </div>
     </div>
-    <!-- Leaflet JS -->
-    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
-    <script src="https://unpkg.com/persian-date@1.1.0/dist/persian-date.min.js"></script>
-    <script src="https://unpkg.com/persian-datepicker@1.2.0/dist/js/persian-datepicker.min.js"></script>
     @stack('scripts')
 </body>
 </html>

--- a/Backend/resources/views/admin/layouts/sidebar.blade.php
+++ b/Backend/resources/views/admin/layouts/sidebar.blade.php
@@ -1,100 +1,107 @@
-<div class="w-64 bg-gray-800 text-white flex-shrink-0 h-full overflow-y-auto">
-    <div class="p-6 text-center">
-        <a href="{{ route('admin.dashboard') }}" class="text-2xl font-bold">پنل مدیریت</a>
+<aside class="w-64 flex-shrink-0 bg-gray-900 text-gray-300 flex flex-col h-full overflow-y-auto">
+    <!-- Logo -->
+    <div class="p-6 text-center border-b border-gray-800">
+        <a href="{{ route('admin.dashboard') }}" class="text-2xl font-semibold text-white">
+            پنل مدیریت
+        </a>
     </div>
-    <nav class="mt-6 flex-1 overflow-y-auto">
-        <a href="{{ route('admin.dashboard') }}" class="flex items-center py-3 px-6 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.dashboard')) bg-gray-700 @endif">
+
+    <!-- Navigation Links -->
+    <nav class="flex-1 px-4 py-4 space-y-2">
+        <!-- Dashboard Link -->
+        <a href="{{ route('admin.dashboard') }}"
+           class="flex items-center px-4 py-3 rounded-lg transition-all duration-200 ease-in-out
+                  {{ request()->routeIs('admin.dashboard') ? 'bg-indigo-600 text-white' : 'hover:bg-gray-800 hover:text-white' }}">
             <i class="ri-dashboard-line text-xl"></i>
-            <span class="mr-4">داشبورد</span>
+            <span class="mr-4 font-medium">داشبورد</span>
         </a>
+
+        <!-- Salons Management Dropdown -->
         <div x-data="{ open: {{ request()->routeIs('admin.salons.*') ? 'true' : 'false' }} }">
-            <a @click="open = !open" href="#" class="flex items-center justify-between py-3 px-6 transition duration-200 hover:bg-gray-700 cursor-pointer">
-                <div class="flex items-center">
+            <button @click="open = !open"
+                    class="w-full flex items-center justify-between px-4 py-3 rounded-lg transition-all duration-200 ease-in-out hover:bg-gray-800 hover:text-white">
+                <span class="flex items-center">
                     <i class="ri-community-line text-xl"></i>
-                    <span class="mr-4">مدیریت سالن‌ها</span>
-                </div>
-                <i class="ri-arrow-down-s-line" :class="{'rotate-180': open}"></i>
-            </a>
-            <div x-show="open" class="pl-8 bg-gray-750">
-                <a href="{{ route('admin.salons.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.salons.index')) bg-gray-600 @endif">
-                    <i class="ri-list-check text-lg"></i>
-                    <span class="mr-3">لیست سالن‌ها</span>
+                    <span class="mr-4 font-medium">مدیریت سالن‌ها</span>
+                </span>
+                <i class="ri-arrow-down-s-line transition-transform duration-300" :class="{'rotate-180': open}"></i>
+            </button>
+            <div x-show="open" x-transition class="mt-1 mr-4 pl-4 border-r-2 border-gray-700 space-y-1">
+                <a href="{{ route('admin.salons.index') }}"
+                   class="block px-4 py-2 rounded-lg text-sm transition-all duration-200 ease-in-out
+                          {{ request()->routeIs('admin.salons.index') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700 hover:text-white' }}">
+                    لیست سالن‌ها
                 </a>
             </div>
         </div>
-        <div x-data="{ open: {{ request()->routeIs('admin.sms-packages.*') || request()->routeIs('admin.manual_sms.*') || request()->routeIs('admin.sms-templates.*') || request()->routeIs('admin.sms_settings.*') || request()->routeIs('admin.bulk-sms-gift.*') ? 'true' : 'false' }} }">
-            <a @click="open = !open" href="#" class="flex items-center justify-between py-3 px-6 transition duration-200 hover:bg-gray-700 cursor-pointer">
-                <div class="flex items-center">
+
+        <!-- SMS Management Dropdown -->
+        <div x-data="{ open: {{ request()->routeIs('admin.sms-packages.*', 'admin.manual_sms.*', 'admin.sms-templates.*', 'admin.sms_settings.*', 'admin.bulk-sms-gift.*') ? 'true' : 'false' }} }">
+            <button @click="open = !open"
+                    class="w-full flex items-center justify-between px-4 py-3 rounded-lg transition-all duration-200 ease-in-out hover:bg-gray-800 hover:text-white">
+                <span class="flex items-center">
                     <i class="ri-message-2-line text-xl"></i>
-                    <span class="mr-4">مدیریت پیامک‌ها</span>
-                </div>
-                <i class="ri-arrow-down-s-line" :class="{'rotate-180': open}"></i>
-            </a>
-            <div x-show="open" class="pl-8 bg-gray-750">
-                <a href="{{ route('admin.sms-packages.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.sms-packages.*')) bg-gray-600 @endif">
-                    <i class="ri-mail-send-line text-lg"></i>
-                    <span class="mr-3">مدیریت پکیج‌ها</span>
-                </a>
-                <a href="{{ route('admin.manual_sms.approval') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.manual_sms.approval')) bg-gray-600 @endif">
-                    <i class="ri-check-double-line text-lg"></i>
-                    <span class="mr-3">تایید پیامک‌های دستی</span>
-                </a>
-                <a href="{{ route('admin.manual_sms.reports') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.manual_sms.reports')) bg-gray-600 @endif">
-                    <i class="ri-bar-chart-box-line text-lg"></i>
-                    <span class="mr-3">گزارش پیامک‌های دستی</span>
-                </a>
-                <a href="{{ route('admin.sms-templates.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.sms-templates.*')) bg-gray-600 @endif">
-                    <i class="ri-file-text-line text-lg"></i>
-                    <span class="mr-3">مدیریت قالب‌ها</span>
-                </a>
-                <a href="{{ route('admin.sms_settings.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.sms_settings.*')) bg-gray-600 @endif">
-                    <i class="ri-settings-3-line text-lg"></i>
-                    <span class="mr-3">تنظیمات پیامک</span>
-                </a>
-                <a href="{{ route('admin.bulk-sms-gift.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.bulk-sms-gift.*')) bg-gray-600 @endif">
-                    <i class="ri-gift-line text-lg"></i>
-                    <span class="mr-3">شارژ گروهی هدیه</span>
-                </a>
+                    <span class="mr-4 font-medium">مدیریت پیامک‌ها</span>
+                </span>
+                <i class="ri-arrow-down-s-line transition-transform duration-300" :class="{'rotate-180': open}"></i>
+            </button>
+            <div x-show="open" x-transition class="mt-1 mr-4 pl-4 border-r-2 border-gray-700 space-y-1">
+                <a href="{{ route('admin.sms-packages.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.sms-packages.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">مدیریت پکیج‌ها</a>
+                <a href="{{ route('admin.manual_sms.approval') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.manual_sms.approval') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">تایید پیامک‌های دستی</a>
+                <a href="{{ route('admin.manual_sms.reports') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.manual_sms.reports') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">گزارش پیامک‌های دستی</a>
+                <a href="{{ route('admin.sms-templates.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.sms-templates.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">مدیریت قالب‌ها</a>
+                <a href="{{ route('admin.sms_settings.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.sms_settings.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">تنظیمات پیامک</a>
+                <a href="{{ route('admin.bulk-sms-gift.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.bulk-sms-gift.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">شارژ گروهی هدیه</a>
             </div>
         </div>
-        <a href="{{ route('admin.app-updates.index') }}" class="flex items-center py-3 px-6 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.app-updates.*')) bg-gray-700 @endif">
-            <i class="ri-refresh-line text-xl"></i> {{-- Using a relevant icon --}}
-            <span class="mr-4">مدیریت آپدیت‌ها</span>
+
+        <!-- App Updates Link -->
+        <a href="{{ route('admin.app-updates.index') }}"
+           class="flex items-center px-4 py-3 rounded-lg transition-all duration-200 ease-in-out
+                  {{ request()->routeIs('admin.app-updates.*') ? 'bg-indigo-600 text-white' : 'hover:bg-gray-800 hover:text-white' }}">
+            <i class="ri-refresh-line text-xl"></i>
+            <span class="mr-4 font-medium">مدیریت آپدیت‌ها</span>
         </a>
-        <a href="{{ route('admin.notifications.index') }}" class="flex items-center py-3 px-6 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.notifications.*')) bg-gray-700 @endif">
+
+        <!-- Notifications Link -->
+        <a href="{{ route('admin.notifications.index') }}"
+           class="flex items-center px-4 py-3 rounded-lg transition-all duration-200 ease-in-out
+                  {{ request()->routeIs('admin.notifications.*') ? 'bg-indigo-600 text-white' : 'hover:bg-gray-800 hover:text-white' }}">
             <i class="ri-notification-3-line text-xl"></i>
-            <span class="mr-4">اعلانات</span>
+            <span class="mr-4 font-medium">اعلانات</span>
         </a>
-        <a href="{{ route('admin.files.index') }}" class="flex items-center py-3 px-6 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.files.*')) bg-gray-700 @endif">
+
+        <!-- Files Link -->
+        <a href="{{ route('admin.files.index') }}"
+           class="flex items-center px-4 py-3 rounded-lg transition-all duration-200 ease-in-out
+                  {{ request()->routeIs('admin.files.*') ? 'bg-indigo-600 text-white' : 'hover:bg-gray-800 hover:text-white' }}">
             <i class="ri-file-line text-xl"></i>
-            <span class="mr-4">فایل ها</span>
+            <span class="mr-4 font-medium">فایل ها</span>
         </a>
-        <a href="{{ route('admin.banners.index') }}" class="flex items-center py-3 px-6 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.banners.*')) bg-gray-700 @endif">
+
+        <!-- Banners Link -->
+        <a href="{{ route('admin.banners.index') }}"
+           class="flex items-center px-4 py-3 rounded-lg transition-all duration-200 ease-in-out
+                  {{ request()->routeIs('admin.banners.*') ? 'bg-indigo-600 text-white' : 'hover:bg-gray-800 hover:text-white' }}">
             <i class="ri-image-line text-xl"></i>
-            <span class="mr-4">مدیریت بنرها</span>
+            <span class="mr-4 font-medium">مدیریت بنرها</span>
         </a>
-        <div x-data="{ open: {{ request()->routeIs('admin.how-introduced.*') || request()->routeIs('admin.professions.*') || request()->routeIs('admin.customer-groups.*') ? 'true' : 'false' }} }">
-            <a @click="open = !open" href="#" class="flex items-center justify-between py-3 px-6 transition duration-200 hover:bg-gray-700 cursor-pointer">
-                <div class="flex items-center">
+
+        <!-- General Settings Dropdown -->
+        <div x-data="{ open: {{ request()->routeIs('admin.how-introduced.*', 'admin.professions.*', 'admin.customer-groups.*') ? 'true' : 'false' }} }">
+            <button @click="open = !open"
+                    class="w-full flex items-center justify-between px-4 py-3 rounded-lg transition-all duration-200 ease-in-out hover:bg-gray-800 hover:text-white">
+                <span class="flex items-center">
                     <i class="ri-settings-4-line text-xl"></i>
-                    <span class="mr-4">تنظیمات عمومی</span>
-                </div>
-                <i class="ri-arrow-down-s-line" :class="{'rotate-180': open}"></i>
-            </a>
-            <div x-show="open" class="pl-8 bg-gray-750">
-                <a href="{{ route('admin.how-introduced.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.how-introduced.*')) bg-gray-600 @endif">
-                    <i class="ri-question-line text-lg"></i>
-                    <span class="mr-3">نحوه آشنایی</span>
-                </a>
-                <a href="{{ route('admin.professions.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.professions.*')) bg-gray-600 @endif">
-                    <i class="ri-briefcase-line text-lg"></i>
-                    <span class="mr-3">مشاغل</span>
-                </a>
-                <a href="{{ route('admin.customer-groups.index') }}" class="flex items-center py-2 px-4 transition duration-200 hover:bg-gray-700 @if(request()->routeIs('admin.customer-groups.*')) bg-gray-600 @endif">
-                    <i class="ri-group-line text-lg"></i>
-                    <span class="mr-3">گروه‌های مشتریان</span>
-                </a>
+                    <span class="mr-4 font-medium">تنظیمات عمومی</span>
+                </span>
+                <i class="ri-arrow-down-s-line transition-transform duration-300" :class="{'rotate-180': open}"></i>
+            </button>
+            <div x-show="open" x-transition class="mt-1 mr-4 pl-4 border-r-2 border-gray-700 space-y-1">
+                <a href="{{ route('admin.how-introduced.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.how-introduced.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">نحوه آشنایی</a>
+                <a href="{{ route('admin.professions.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.professions.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">مشاغل</a>
+                <a href="{{ route('admin.customer-groups.index') }}" class="block px-4 py-2 rounded-lg text-sm {{ request()->routeIs('admin.customer-groups.*') ? 'bg-gray-700 text-white' : 'hover:bg-gray-700' }}">گروه‌های مشتریان</a>
             </div>
         </div>
     </nav>
-</div>
+</aside>

--- a/Backend/resources/views/admin/sms-reports/index.blade.php
+++ b/Backend/resources/views/admin/sms-reports/index.blade.php
@@ -40,13 +40,11 @@
                                 <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
                                     <p class="text-gray-900 whitespace-no-wrap">{{ $batch->salon_name }}</p>
                                 </td>
-                                <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm" style="white-space: normal; word-break: break-word;">
-                                    @if ($batch->edited_content)
-                                        <p class="text-gray-900">ارسال شده: {{ Str::limit($batch->edited_content, 50) }}</p>
-                                        <p class="text-gray-500 text-xs mt-1">اصلی: {{ Str::limit($batch->original_content, 50) }}</p>
-                                    @else
-                                        <p class="text-gray-900">اصلی: {{ Str::limit($batch->original_content ?? $batch->content, 50) }}</p>
-                                    @endif
+                                <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+                                    <button onclick='openViewModal(@json($batch))' class="inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                        <i class="ri-eye-line ml-1"></i>
+                                        مشاهده
+                                    </button>
                                 </td>
                                 <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
                                     <p class="text-gray-900 whitespace-no-wrap">{{ $batch->recipients_count }}</p>
@@ -64,7 +62,7 @@
                                         </span>
                                     @elseif ($batch->approval_status == 'rejected')
                                         <span class="relative inline-block px-3 py-1 font-semibold text-red-900 leading-tight">
-                                            <span aria-hidden class="absolute inset-0 bg-red-200 opacity-50 rounded-full"></span>
+                                            <span aria-hidden="true" class="absolute inset-0 bg-red-200 opacity-50 rounded-full"></span>
                                             <span class="relative">رد شده</span>
                                         </span>
                                     @endif
@@ -96,4 +94,72 @@
         </div>
     </div>
 </div>
+
+<!-- Modal -->
+<div id="viewMessageModal" class="fixed z-10 inset-0 overflow-y-auto hidden" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+    <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="closeViewModal()"></div>
+        <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+        <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+            <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex">
+                <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100 sm:mx-0 sm:h-10 sm:w-10">
+                    <i class="ri-file-text-line text-2xl text-indigo-600"></i>
+                </div>
+                <div class="mt-3 text-center sm:mt-0 sm:mr-4 sm:text-right w-full">
+                    <h3 class="text-lg leading-6 font-medium text-gray-900">
+                        مشاهده متن پیام
+                    </h3>
+                </div>
+            </div>
+            <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                <div class="sm:flex sm:items-start">
+                    <div class="w-full">
+                        <div class="space-y-4">
+                            <div id="editedContentContainer" class="hidden">
+                                <p class="text-sm font-bold text-gray-700">متن ارسال شده:</p>
+                                <p id="editedContent" class="text-sm text-gray-600 mt-1 p-3 bg-gray-100 rounded-md whitespace-pre-wrap"></p>
+                            </div>
+                            <div>
+                                <p class="text-sm font-bold text-gray-700">متن اصلی:</p>
+                                <p id="originalContent" class="text-sm text-gray-600 mt-1 p-3 bg-gray-100 rounded-md whitespace-pre-wrap"></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                <button onclick="closeViewModal()" type="button" class="btn-secondary w-full sm:w-auto">
+                    بستن
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
 @endsection
+
+@push('scripts')
+<script>
+    function openViewModal(batch) {
+        const modal = document.getElementById('viewMessageModal');
+        const originalContentEl = document.getElementById('originalContent');
+        const editedContentEl = document.getElementById('editedContent');
+        const editedContentContainer = document.getElementById('editedContentContainer');
+
+        originalContentEl.innerText = batch.original_content || batch.content;
+
+        if (batch.edited_content && batch.original_content !== batch.edited_content) {
+            editedContentEl.innerText = batch.edited_content;
+            editedContentContainer.classList.remove('hidden');
+        } else {
+            editedContentContainer.classList.add('hidden');
+        }
+
+        modal.classList.remove('hidden');
+    }
+
+    function closeViewModal() {
+        const modal = document.getElementById('viewMessageModal');
+        modal.classList.add('hidden');
+    }
+</script>
+@endpush

--- a/Backend/resources/views/admin/sms-templates/approval.blade.php
+++ b/Backend/resources/views/admin/sms-templates/approval.blade.php
@@ -84,11 +84,11 @@
                                             @endphp
                                             {{ $recipientsType }}
                                         </td>
-                                        <td class="px-6 py-4 text-sm text-gray-500" style="white-space: normal; word-break: break-word;">
-                                            <p id="display_content_{{ $batch->batch_id }}" class="text-gray-900">{{ $batch->display_content }}</p>
-                                            @if ($batch->original_content && $batch->original_content != $batch->edited_content)
-                                                <p class="text-xs text-gray-400 mt-1">متن اصلی: {{ $batch->original_content }}</p>
-                                            @endif
+                                        <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                            <button onclick='openViewModal(@json($batch))' class="inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-medium rounded text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500">
+                                                <i class="ri-eye-line ml-1"></i>
+                                                مشاهده
+                                            </button>
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                                             {{ $batch->recipients_count }}
@@ -97,7 +97,7 @@
                                             {{ \Morilog\Jalali\Jalalian::fromCarbon($batch->created_at)->format('Y/m/d H:i') }}
                                         </td>
                                         <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                                            <button onclick="openEditModal('{{ $batch->batch_id }}', '{{ addslashes($batch->display_content) }}')" class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mb-2">
+                                            <button onclick='openEditModal(@json($batch))' class="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mb-2">
                                                 ویرایش پیام
                                             </button>
                                             <form id="approveForm_{{ $batch->batch_id }}" action="{{ route('admin.manual_sms.approve', $batch->batch_id) }}" method="POST" class="inline-block mr-2">
@@ -140,12 +140,9 @@
                 <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                     <div class="sm:flex sm:items-start w-full">
                         <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-blue-100 sm:mx-0 sm:h-10 sm:w-10">
-                            <!-- Heroicon name: outline/pencil -->
-                            <svg class="h-6 w-6 text-blue-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
-                            </svg>
+                            <i class="ri-pencil-line text-2xl text-blue-600"></i>
                         </div>
-                        <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-right w-full">
+                        <div class="mt-3 text-center sm:mt-0 sm:mr-4 sm:text-right w-full">
                             <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">
                                 ویرایش پیامک
                             </h3>
@@ -153,7 +150,7 @@
                                 <p class="text-sm text-gray-500">
                                     متن پیامک را ویرایش کنید.
                                 </p>
-                                <textarea id="edit_message_content_textarea" rows="6" class="mt-2 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md"></textarea>
+                                <textarea id="edit_message_content_textarea" rows="6" class="mt-2 shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-400 rounded-md bg-gray-50"></textarea>
                             </div>
                         </div>
                     </div>
@@ -181,11 +178,9 @@
                     <div class="bg-white px-4 pt-5 pb-4 sm:p-6 w-full sm:pb-4">
                         <div class="sm:flex sm:items-start w-full">
                             <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
-                                <svg class="h-6 w-6 text-red-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                                </svg>
+                                <i class="ri-close-circle-line text-2xl text-red-600"></i>
                             </div>
-                            <div class="mt-3 w-full text-center sm:mt-0 sm:ml-4 sm:text-right w-full">
+                            <div class="mt-3 w-full text-center sm:mt-0 sm:mr-4 sm:text-right w-full">
                                 <h3 class="text-lg leading-6 font-medium text-gray-900" id="modal-title">
                                     رد کردن درخواست پیامک
                                 </h3>
@@ -211,8 +206,72 @@
         </div>
     </div>
 
+    <!-- View Message Modal -->
+    <div id="viewMessageModal" class="fixed z-10 inset-0 overflow-y-auto hidden" aria-labelledby="modal-title" role="dialog" aria-modal="true">
+        <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+            <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true" onclick="closeViewModal()"></div>
+            <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
+            <div class="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+                <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex">
+                    <div class="mx-auto flex-shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-indigo-100 sm:mx-0 sm:h-10 sm:w-10">
+                        <i class="ri-file-text-line text-2xl text-indigo-600"></i>
+                    </div>
+                    <div class="mt-3 text-center sm:mt-0 sm:mr-4 sm:text-right w-full">
+                        <h3 class="text-lg leading-6 font-medium text-gray-900">
+                            مشاهده متن پیام
+                        </h3>
+                    </div>
+                </div>
+                <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                    <div class="sm:flex sm:items-start">
+                        <div class="w-full">
+                            <div class="space-y-4">
+                                <div id="editedContentContainer" class="hidden">
+                                    <p class="text-sm font-bold text-gray-700">متن ویرایش شده:</p>
+                                    <p id="editedContent" class="text-sm text-gray-600 mt-1 p-3 bg-gray-100 rounded-md whitespace-pre-wrap"></p>
+                                </div>
+                                <div>
+                                    <p class="text-sm font-bold text-gray-700">متن اصلی:</p>
+                                    <p id="originalContent" class="text-sm text-gray-600 mt-1 p-3 bg-gray-100 rounded-md whitespace-pre-wrap"></p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                    <button onclick="closeViewModal()" type="button" class="btn-secondary w-full sm:w-auto">
+                        بستن
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <script>
         let currentEditingBatchId = null;
+
+        function openViewModal(batch) {
+            const modal = document.getElementById('viewMessageModal');
+            const originalContentEl = document.getElementById('originalContent');
+            const editedContentEl = document.getElementById('editedContent');
+            const editedContentContainer = document.getElementById('editedContentContainer');
+
+            originalContentEl.innerText = batch.original_content || batch.content;
+
+            if (batch.edited_content && batch.original_content !== batch.edited_content) {
+                editedContentEl.innerText = batch.edited_content;
+                editedContentContainer.classList.remove('hidden');
+            } else {
+                editedContentContainer.classList.add('hidden');
+            }
+
+            modal.classList.remove('hidden');
+        }
+
+        function closeViewModal() {
+            const modal = document.getElementById('viewMessageModal');
+            modal.classList.add('hidden');
+        }
 
         function openRejectModal(batchId) {
             const modal = document.getElementById('rejectModal');
@@ -226,11 +285,11 @@
             modal.classList.add('hidden');
         }
 
-        function openEditModal(batchId, content) {
-            currentEditingBatchId = batchId;
+        function openEditModal(batch) {
+            currentEditingBatchId = batch.batch_id;
             const modal = document.getElementById('editMessageModal');
             const textarea = document.getElementById('edit_message_content_textarea');
-            textarea.value = content;
+            textarea.value = batch.display_content;
             modal.classList.remove('hidden');
         }
 
@@ -259,8 +318,6 @@
 
                 if (response.ok) {
                     alert(data.message);
-                    // Update the displayed content in the table
-                    document.getElementById(`display_content_${currentEditingBatchId}`).innerText = editedContent;
                     // Update the hidden input for the approve form
                     document.getElementById(`approve_message_content_${currentEditingBatchId}`).value = editedContent;
                     closeEditModal();

--- a/Backend/vite.config.js
+++ b/Backend/vite.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import laravel from 'laravel-vite-plugin';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 
 export default defineConfig({
     plugins: [
@@ -7,6 +8,14 @@ export default defineConfig({
             input: ['resources/css/app.css', 'resources/js/app.js'],
             refresh: true,
         }),
+        viteStaticCopy({
+            targets: [
+                {
+                    src: 'node_modules/remixicon/fonts',
+                    dest: ''
+                }
+            ]
+        })
     ],
     server: {
         host: '127.0.0.1',


### PR DESCRIPTION
This commit introduces a new scheduled command to automatically cancel past appointments that are still marked as 'confirmed' or 'pending_confirmation'.

Additionally, it enhances appointment data by:
*   Adding detailed appointment counts (total, active, canceled) to salon and customer API responses.
*   Including an `is_past` attribute in the `AppointmentResource`.

The admin sidebar's SMS management section has been refactored into a more organized, collapsible menu, improving navigation for SMS packages, manual SMS approval/reports, templates, and settings.

Finally, frontend dependencies and Vite configuration have been updated.