### PR TITLE
feat: Add transaction categories and subcategories management

### DIFF
--- a/Backend/app/Http/Controllers/Api/OnlineBookingSettingController.php
+++ b/Backend/app/Http/Controllers/Api/OnlineBookingSettingController.php
@@ -8,9 +8,8 @@ use Illuminate\Http\Request;
 
 class OnlineBookingSettingController extends Controller
 {
-    public function show($salonId)
+    public function show(Salon $salon)
     {
-        $salon = Salon::findOrFail($salonId);
         
         $defaults = [
             'default_booking_status' => 'pending_confirmation',
@@ -30,7 +29,7 @@ class OnlineBookingSettingController extends Controller
         ]);
     }
 
-    public function update(Request $request, $salonId)
+    public function update(Request $request, Salon $salon)
     {
         $request->validate([
             'default_booking_status' => 'sometimes|required|in:pending_confirmation,confirmed',
@@ -39,8 +38,6 @@ class OnlineBookingSettingController extends Controller
             'enabled_days.*' => 'integer|min:0|max:6',
             'allow_holiday_booking' => 'sometimes|required|boolean',
         ]);
-
-        $salon = Salon::findOrFail($salonId);
         
         $settings = $salon->online_booking_settings ?? [];
         

--- a/Backend/app/Http/Controllers/CashboxController.php
+++ b/Backend/app/Http/Controllers/CashboxController.php
@@ -163,6 +163,8 @@ class CashboxController extends Controller
             'cashbox_id' => 'required|exists:cashboxes,id',
             'amount' => 'required|numeric|min:0.01',
             'description' => 'nullable|string',
+            'category_id' => 'nullable|exists:transaction_categories,id',
+            'subcategory_id' => 'nullable|exists:transaction_subcategories,id',
             'category' => 'nullable|string',
             'subcategory' => 'nullable|string',
             'transaction_date' => 'nullable|date',
@@ -172,6 +174,8 @@ class CashboxController extends Controller
             'cashbox_id.exists' => 'صندوق انتخابی یافت نشد',
             'amount.required' => 'مبلغ الزامی است',
             'amount.min' => 'مبلغ باید بیشتر از صفر باشد',
+            'category_id.exists' => 'دسته‌بندی انتخابی یافت نشد',
+            'subcategory_id.exists' => 'زیردسته انتخابی یافت نشد',
         ]);
 
         if ($validator->fails()) {
@@ -198,6 +202,8 @@ class CashboxController extends Controller
             'cashbox_id' => 'required|exists:cashboxes,id',
             'amount' => 'required|numeric|min:0.01',
             'description' => 'nullable|string',
+            'category_id' => 'nullable|exists:transaction_categories,id',
+            'subcategory_id' => 'nullable|exists:transaction_subcategories,id',
             'category' => 'nullable|string',
             'subcategory' => 'nullable|string',
             'transaction_date' => 'nullable|date',
@@ -207,6 +213,8 @@ class CashboxController extends Controller
             'cashbox_id.exists' => 'صندوق انتخابی یافت نشد',
             'amount.required' => 'مبلغ الزامی است',
             'amount.min' => 'مبلغ باید بیشتر از صفر باشد',
+            'category_id.exists' => 'دسته‌بندی انتخابی یافت نشد',
+            'subcategory_id.exists' => 'زیردسته انتخابی یافت نشد',
         ]);
 
         if ($validator->fails()) {

--- a/Backend/app/Http/Controllers/CommissionController.php
+++ b/Backend/app/Http/Controllers/CommissionController.php
@@ -107,6 +107,13 @@ class CommissionController extends Controller
     /**
      * دریافت تراکنش‌های پورسانت یک کارکن
      * GET /salons/{salon}/commissions/staff/{staff}/transactions
+     * 
+     * Query Parameters:
+     * - payment_status: pending|paid (فیلتر بر اساس وضعیت پرداخت)
+     * - transaction_type: commission|adjustment|payment (فیلتر بر اساس نوع تراکنش)
+     * - year, month: فیلتر بر اساس تاریخ ثبت تراکنش (شمسی)
+     * - payment_period_year, payment_period_month: فیلتر بر اساس دوره پرداخت (برای پرداخت‌ها)
+     * - per_page: تعداد در هر صفحه (پیش‌فرض: 20)
      */
     public function staffTransactions(Request $request, Salon $salon, Staff $staff)
     {
@@ -127,9 +134,17 @@ class CommissionController extends Controller
             $query->where('transaction_type', $request->input('transaction_type'));
         }
 
-        // فیلتر بر اساس ماه و سال شمسی
+        // فیلتر بر اساس ماه و سال شمسی (تاریخ ثبت)
         if ($request->filled('year') && $request->filled('month')) {
             $query->inJalaliMonth((int) $request->input('year'), (int) $request->input('month'));
+        }
+
+        // فیلتر بر اساس دوره پرداخت (برای پرداخت‌ها)
+        if ($request->filled('payment_period_year') && $request->filled('payment_period_month')) {
+            $query->forPaymentPeriod(
+                (int) $request->input('payment_period_year'), 
+                (int) $request->input('payment_period_month')
+            );
         }
 
         $transactions = $query->orderBy('created_at', 'desc')

--- a/Backend/app/Http/Controllers/ReportController.php
+++ b/Backend/app/Http/Controllers/ReportController.php
@@ -8,6 +8,7 @@ use App\Services\Reports\FinanceReportService;
 use App\Services\Reports\PersonnelReportService;
 use App\Services\Reports\SatisfactionReportService;
 use App\Services\Reports\SmsReportService;
+use App\Services\Reports\AppointmentReportService;
 use App\Services\Reports\ReportPdfService;
 use App\Models\SharedReport;
 use App\Traits\ConvertsPersianDates;
@@ -25,6 +26,7 @@ class ReportController extends Controller
     protected $personnelReportService;
     protected $satisfactionReportService;
     protected $smsReportService;
+    protected $appointmentReportService;
     protected $pdfService;
 
     public function __construct(
@@ -34,6 +36,7 @@ class ReportController extends Controller
         PersonnelReportService $personnelReportService,
         SatisfactionReportService $satisfactionReportService,
         SmsReportService $smsReportService,
+        AppointmentReportService $appointmentReportService,
         ReportPdfService $pdfService
     ) {
         $this->customerReportService = $customerReportService;
@@ -42,6 +45,7 @@ class ReportController extends Controller
         $this->personnelReportService = $personnelReportService;
         $this->satisfactionReportService = $satisfactionReportService;
         $this->smsReportService = $smsReportService;
+        $this->appointmentReportService = $appointmentReportService;
         $this->pdfService = $pdfService;
     }
 
@@ -192,6 +196,72 @@ class ReportController extends Controller
         $filters = $this->convertPersianDates($filters);
 
         $report = $this->reservationReportService->generateCustomReport($salonId, $filters);
+
+        return response()->json([
+            'success' => true,
+            'data' => $report,
+        ]);
+    }
+
+    /**
+     * Get preset appointment report.
+     */
+    public function appointmentsPreset(Request $request)
+    {
+        $salonId = $request->user()->active_salon_id;
+        $period = $request->input('period', 'weekly');
+
+        $report = $this->appointmentReportService->generatePresetReport($salonId, $period);
+
+        return response()->json([
+            'success' => true,
+            'data' => $report,
+        ]);
+    }
+
+    /**
+     * Get custom appointment report.
+     */
+    public function appointmentsCustom(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'date_from' => 'nullable|date',
+            'date_to' => 'nullable|date|after_or_equal:date_from',
+            'time_from' => 'nullable|date_format:H:i',
+            'time_to' => 'nullable|date_format:H:i',
+            'status' => 'nullable|array',
+            'status.*' => 'string|in:pending,confirmed,completed,canceled,cancelled,no_show,all',
+            'service_ids' => 'nullable|array',
+            'service_ids.*' => 'integer|min:0',
+            'personnel_ids' => 'nullable|array',
+            'personnel_ids.*' => 'integer|min:0',
+            'customer_ids' => 'nullable|array',
+            'customer_ids.*' => 'integer|min:0',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $salonId = $request->user()->active_salon_id;
+        $filters = $request->only([
+            'date_from',
+            'date_to',
+            'time_from',
+            'time_to',
+            'status',
+            'service_ids',
+            'personnel_ids',
+            'customer_ids',
+        ]);
+        
+        // Convert Persian dates to Gregorian if needed
+        $filters = $this->convertPersianDates($filters);
+
+        $report = $this->appointmentReportService->generateCustomReport($salonId, $filters);
 
         return response()->json([
             'success' => true,

--- a/Backend/app/Http/Controllers/TransactionCategoryController.php
+++ b/Backend/app/Http/Controllers/TransactionCategoryController.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TransactionCategory;
+use App\Models\TransactionSubcategory;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class TransactionCategoryController extends Controller
+{
+    /**
+     * لیست دسته‌بندی‌ها
+     */
+    public function index(Request $request, $salon)
+    {
+        $query = TransactionCategory::forSalon($salon->id)
+            ->with(['activeSubcategories'])
+            ->ordered();
+
+        // فیلتر بر اساس نوع (income, expense, both)
+        if ($request->has('type')) {
+            $query->byType($request->type);
+        }
+
+        // فیلتر بر اساس وضعیت
+        if ($request->has('is_active')) {
+            $query->where('is_active', $request->is_active);
+        }
+
+        // نمایش یا عدم نمایش دسته‌های سیستمی
+        if ($request->has('include_system') && $request->include_system == false) {
+            $query->where('is_system', false);
+        }
+
+        $categories = $query->get();
+
+        return response()->json([
+            'success' => true,
+            'categories' => $categories,
+        ]);
+    }
+
+    /**
+     * ایجاد دسته‌بندی جدید
+     */
+    public function store(Request $request, $salon)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'type' => 'nullable|in:both,income,expense',
+            'description' => 'nullable|string',
+            'is_active' => 'nullable|boolean',
+            'sort_order' => 'nullable|integer|min:0',
+        ], [
+            'name.required' => 'نام دسته‌بندی الزامی است',
+            'type.in' => 'نوع دسته‌بندی نامعتبر است',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+        $data['salon_id'] = $salon->id;
+        $data['is_system'] = false; // دسته‌های کاربر همیشه غیرسیستمی هستند
+
+        $category = TransactionCategory::create($data);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'دسته‌بندی با موفقیت ایجاد شد',
+            'category' => $category,
+        ], 201);
+    }
+
+    /**
+     * نمایش جزئیات دسته‌بندی
+     */
+    public function show($salon, $id)
+    {
+        $category = TransactionCategory::forSalon($salon->id)
+            ->with(['subcategories' => function ($q) {
+                $q->ordered();
+            }])
+            ->findOrFail($id);
+
+        return response()->json([
+            'success' => true,
+            'category' => $category,
+        ]);
+    }
+
+    /**
+     * ویرایش دسته‌بندی
+     */
+    public function update(Request $request, $salon, $id)
+    {
+        $category = TransactionCategory::forSalon($salon->id)->findOrFail($id);
+
+        // بررسی امکان ویرایش
+        if ($category->isSystem()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'دسته‌بندی‌های سیستمی قابل ویرایش نیستند',
+            ], 403);
+        }
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'sometimes|required|string|max:255',
+            'type' => 'nullable|in:both,income,expense',
+            'description' => 'nullable|string',
+            'is_active' => 'nullable|boolean',
+            'sort_order' => 'nullable|integer|min:0',
+        ], [
+            'name.required' => 'نام دسته‌بندی الزامی است',
+            'type.in' => 'نوع دسته‌بندی نامعتبر است',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $category->update($validator->validated());
+
+        return response()->json([
+            'success' => true,
+            'message' => 'دسته‌بندی با موفقیت به‌روزرسانی شد',
+            'category' => $category->fresh(),
+        ]);
+    }
+
+    /**
+     * حذف دسته‌بندی
+     */
+    public function destroy($salon, $id)
+    {
+        $category = TransactionCategory::forSalon($salon->id)->findOrFail($id);
+
+        // بررسی امکان حذف
+        if (!$category->canBeDeleted()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'دسته‌بندی‌های سیستمی قابل حذف نیستند',
+            ], 403);
+        }
+
+        // حذف نرم - زیردسته‌ها هم به صورت خودکار حذف می‌شوند (cascade)
+        $category->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'دسته‌بندی با موفقیت حذف شد',
+        ]);
+    }
+
+    /**
+     * لیست زیردسته‌های یک دسته‌بندی
+     */
+    public function subcategories(Request $request, $salon, $categoryId)
+    {
+        // بررسی وجود دسته‌بندی
+        $category = TransactionCategory::forSalon($salon->id)->findOrFail($categoryId);
+
+        $query = TransactionSubcategory::forCategory($categoryId)
+            ->forSalon($salon->id)
+            ->with(['service'])
+            ->ordered();
+
+        // فیلتر بر اساس وضعیت
+        if ($request->has('is_active')) {
+            $query->where('is_active', $request->is_active);
+        }
+
+        $subcategories = $query->get();
+
+        return response()->json([
+            'success' => true,
+            'category' => $category,
+            'subcategories' => $subcategories,
+        ]);
+    }
+
+    /**
+     * ایجاد زیردسته جدید
+     */
+    public function storeSubcategory(Request $request, $salon, $categoryId)
+    {
+        // بررسی وجود دسته‌بندی
+        $category = TransactionCategory::forSalon($salon->id)->findOrFail($categoryId);
+
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string|max:255',
+            'description' => 'nullable|string',
+            'service_id' => 'nullable|exists:services,id',
+            'is_active' => 'nullable|boolean',
+            'sort_order' => 'nullable|integer|min:0',
+        ], [
+            'name.required' => 'نام زیردسته الزامی است',
+            'service_id.exists' => 'خدمت انتخابی یافت نشد',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $data = $validator->validated();
+        $data['category_id'] = $categoryId;
+        $data['salon_id'] = $salon->id;
+
+        $subcategory = TransactionSubcategory::create($data);
+
+        return response()->json([
+            'success' => true,
+            'message' => 'زیردسته با موفقیت ایجاد شد',
+            'subcategory' => $subcategory->load('service'),
+        ], 201);
+    }
+
+    /**
+     * نمایش جزئیات زیردسته
+     */
+    public function showSubcategory($salon, $categoryId, $subcategoryId)
+    {
+        $subcategory = TransactionSubcategory::forCategory($categoryId)
+            ->forSalon($salon->id)
+            ->with(['category', 'service'])
+            ->findOrFail($subcategoryId);
+
+        return response()->json([
+            'success' => true,
+            'subcategory' => $subcategory,
+        ]);
+    }
+
+    /**
+     * ویرایش زیردسته
+     */
+    public function updateSubcategory(Request $request, $salon, $categoryId, $subcategoryId)
+    {
+        $subcategory = TransactionSubcategory::forCategory($categoryId)
+            ->forSalon($salon->id)
+            ->findOrFail($subcategoryId);
+
+        // اگر زیردسته به خدمات لینک است، نمی‌شود نام آن را تغییر داد
+        $rules = [
+            'description' => 'nullable|string',
+            'service_id' => 'nullable|exists:services,id',
+            'is_active' => 'nullable|boolean',
+            'sort_order' => 'nullable|integer|min:0',
+        ];
+
+        if (!$subcategory->isLinkedToService()) {
+            $rules['name'] = 'sometimes|required|string|max:255';
+        }
+
+        $validator = Validator::make($request->all(), $rules, [
+            'name.required' => 'نام زیردسته الزامی است',
+            'service_id.exists' => 'خدمت انتخابی یافت نشد',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json([
+                'success' => false,
+                'errors' => $validator->errors(),
+            ], 422);
+        }
+
+        $subcategory->update($validator->validated());
+
+        return response()->json([
+            'success' => true,
+            'message' => 'زیردسته با موفقیت به‌روزرسانی شد',
+            'subcategory' => $subcategory->fresh(['service']),
+        ]);
+    }
+
+    /**
+     * حذف زیردسته
+     */
+    public function destroySubcategory($salon, $categoryId, $subcategoryId)
+    {
+        $subcategory = TransactionSubcategory::forCategory($categoryId)
+            ->forSalon($salon->id)
+            ->findOrFail($subcategoryId);
+
+        // اگر زیردسته به خدمات لینک است، نباید حذف شود
+        if ($subcategory->isLinkedToService()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'زیردسته‌های مرتبط با خدمات قابل حذف نیستند',
+            ], 403);
+        }
+
+        $subcategory->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'زیردسته با موفقیت حذف شد',
+        ]);
+    }
+}

--- a/Backend/app/Http/Requests/PrepareManualFollowupRequest.php
+++ b/Backend/app/Http/Requests/PrepareManualFollowupRequest.php
@@ -17,9 +17,17 @@ class PrepareManualFollowupRequest extends FormRequest
     {
         return [
             'customer_group_ids' => ['nullable', 'array'],
-            'customer_group_ids.*' => ['exists:customer_groups,id'],
+            'customer_group_ids.*' => ['integer', function ($attribute, $value, $fail) {
+                if ($value != 0 && !\App\Models\CustomerGroup::where('id', $value)->exists()) {
+                    $fail('گروه مشتری انتخاب شده معتبر نیست.');
+                }
+            }],
             'service_ids' => ['nullable', 'array'],
-            'service_ids.*' => ['exists:services,id'],
+            'service_ids.*' => ['integer', function ($attribute, $value, $fail) {
+                if ($value != 0 && !\App\Models\Service::where('id', $value)->exists()) {
+                    $fail('سرویس انتخاب شده معتبر نیست.');
+                }
+            }],
             'days_since_last_visit' => ['required', 'integer', 'min:1', 'max:365'],
             'template_id' => ['required', 'exists:salon_sms_templates,id'],
         ];

--- a/Backend/app/Http/Resources/ServiceResource.php
+++ b/Backend/app/Http/Resources/ServiceResource.php
@@ -14,16 +14,18 @@ class ServiceResource extends JsonResource
      */
     public function toArray(Request $request): array
     {
+        $durationMinutes = $this->duration_minutes; // Capture outside closure
+        
         return [
             'id' => $this->id,
             'name' => $this->name,
             'duration_minutes' => $this->duration_minutes,
-            'pivot' => $this->whenPivotLoaded('appointment_service', function () {
+            'pivot' => $this->whenPivotLoaded('appointment_service', function () use ($durationMinutes) {
                 return [
                     'appointment_id' => $this->pivot->appointment_id,
                     'service_id' => $this->pivot->service_id,
                     'price_at_booking' => $this->pivot->price_at_booking,
-                    // 'duration_at_booking' => $this->pivot->duration_at_booking, // Removed as total_duration is now on appointment
+                    'duration_at_booking' => $durationMinutes, // Use service's duration_minutes for backward compatibility
                     'created_at' => $this->pivot->created_at,
                     'updated_at' => $this->pivot->updated_at,
                 ];

--- a/Backend/app/Models/CashboxTransaction.php
+++ b/Backend/app/Models/CashboxTransaction.php
@@ -19,6 +19,8 @@ class CashboxTransaction extends Model
         'to_cashbox_id',
         'amount',
         'description',
+        'category_id',
+        'subcategory_id',
         'category',
         'subcategory',
         'payment_id',
@@ -75,6 +77,16 @@ class CashboxTransaction extends Model
     public function commissionTransaction()
     {
         return $this->belongsTo(StaffCommissionTransaction::class, 'commission_transaction_id');
+    }
+
+    public function transactionCategory()
+    {
+        return $this->belongsTo(TransactionCategory::class, 'category_id');
+    }
+
+    public function transactionSubcategory()
+    {
+        return $this->belongsTo(TransactionSubcategory::class, 'subcategory_id');
     }
 
     public function creator()

--- a/Backend/app/Models/StaffCommissionTransaction.php
+++ b/Backend/app/Models/StaffCommissionTransaction.php
@@ -43,9 +43,11 @@ class StaffCommissionTransaction extends Model
         'commission_rate' => 'decimal:2',
         'amount' => 'decimal:2',
         'paid_at' => 'datetime',
+        'for_month' => 'integer',
+        'for_year' => 'integer',
     ];
 
-    protected $appends = ['jalali_created_at', 'jalali_paid_at'];
+    protected $appends = ['jalali_created_at', 'jalali_paid_at', 'payment_period_display'];
 
     // ثابت‌های نوع تراکنش
     const TYPE_COMMISSION = 'commission';
@@ -119,6 +121,24 @@ class StaffCommissionTransaction extends Model
     }
 
     /**
+     * نمایش دوره پرداخت (ماه و سال شمسی)
+     */
+    public function getPaymentPeriodDisplayAttribute(): ?string
+    {
+        if ($this->for_month && $this->for_year) {
+            $monthNames = [
+                1 => 'فروردین', 2 => 'اردیبهشت', 3 => 'خرداد',
+                4 => 'تیر', 5 => 'مرداد', 6 => 'شهریور',
+                7 => 'مهر', 8 => 'آبان', 9 => 'آذر',
+                10 => 'دی', 11 => 'بهمن', 12 => 'اسفند'
+            ];
+            $monthName = $monthNames[$this->for_month] ?? $this->for_month;
+            return $monthName . ' ' . $this->for_year;
+        }
+        return null;
+    }
+
+    /**
      * اسکوپ برای فیلتر بر اساس وضعیت پرداخت
      */
     public function scopePending($query)
@@ -171,6 +191,14 @@ class StaffCommissionTransaction extends Model
         $endDate = $endJalali->toCarbon()->endOfDay();
 
         return $query->whereBetween('created_at', [$startDate, $endDate]);
+    }
+
+    /**
+     * اسکوپ برای فیلتر بر اساس دوره پرداخت (for_month و for_year)
+     */
+    public function scopeForPaymentPeriod($query, int $year, int $month)
+    {
+        return $query->where('for_year', $year)->where('for_month', $month);
     }
 
     /**

--- a/Backend/app/Models/TransactionCategory.php
+++ b/Backend/app/Models/TransactionCategory.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class TransactionCategory extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'salon_id',
+        'name',
+        'type',
+        'description',
+        'is_system',
+        'is_active',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'is_system' => 'boolean',
+        'is_active' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    // انواع دسته‌بندی
+    const TYPE_BOTH = 'both';       // برای هر دو ورودی و خروجی
+    const TYPE_INCOME = 'income';   // فقط برای ورودی
+    const TYPE_EXPENSE = 'expense'; // فقط برای خروجی
+
+    /**
+     * Relationships
+     */
+    public function salon()
+    {
+        return $this->belongsTo(Salon::class);
+    }
+
+    public function subcategories()
+    {
+        return $this->hasMany(TransactionSubcategory::class, 'category_id');
+    }
+
+    public function activeSubcategories()
+    {
+        return $this->subcategories()->where('is_active', true)->orderBy('sort_order')->orderBy('name');
+    }
+
+    /**
+     * Scopes
+     */
+    public function scopeForSalon($query, $salonId)
+    {
+        return $query->where('salon_id', $salonId);
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function scopeSystem($query)
+    {
+        return $query->where('is_system', true);
+    }
+
+    public function scopeByType($query, $type)
+    {
+        return $query->where(function ($q) use ($type) {
+            $q->where('type', $type)
+              ->orWhere('type', self::TYPE_BOTH);
+        });
+    }
+
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('sort_order')->orderBy('name');
+    }
+
+    /**
+     * Methods
+     */
+    public function isSystem(): bool
+    {
+        return $this->is_system === true;
+    }
+
+    public function canBeDeleted(): bool
+    {
+        // دسته‌های سیستمی قابل حذف نیستند
+        return !$this->isSystem();
+    }
+}

--- a/Backend/app/Models/TransactionSubcategory.php
+++ b/Backend/app/Models/TransactionSubcategory.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class TransactionSubcategory extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'category_id',
+        'salon_id',
+        'name',
+        'description',
+        'service_id',
+        'is_active',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'is_active' => 'boolean',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * Relationships
+     */
+    public function category()
+    {
+        return $this->belongsTo(TransactionCategory::class, 'category_id');
+    }
+
+    public function salon()
+    {
+        return $this->belongsTo(Salon::class);
+    }
+
+    public function service()
+    {
+        return $this->belongsTo(Service::class);
+    }
+
+    /**
+     * Scopes
+     */
+    public function scopeForSalon($query, $salonId)
+    {
+        return $query->where('salon_id', $salonId);
+    }
+
+    public function scopeForCategory($query, $categoryId)
+    {
+        return $query->where('category_id', $categoryId);
+    }
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function scopeOrdered($query)
+    {
+        return $query->orderBy('sort_order')->orderBy('name');
+    }
+
+    /**
+     * Methods
+     */
+    public function isLinkedToService(): bool
+    {
+        return !is_null($this->service_id);
+    }
+}

--- a/Backend/app/Observers/SalonObserver.php
+++ b/Backend/app/Observers/SalonObserver.php
@@ -6,6 +6,7 @@ use App\Models\Salon;
 use App\Models\Profession;
 use App\Models\HowIntroduced;
 use App\Models\CustomerGroup;
+use Database\Seeders\TransactionCategorySeeder;
 
 class SalonObserver
 {
@@ -40,5 +41,8 @@ class SalonObserver
                 ['name' => $customerGroup->name]
             );
         }
+
+        // ایجاد دسته پیش‌فرض "خدمات" برای تراکنش‌های مالی
+        TransactionCategorySeeder::createServicesCategory($salon);
     }
 }

--- a/Backend/app/Observers/ServiceObserver.php
+++ b/Backend/app/Observers/ServiceObserver.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Service;
+use App\Models\TransactionCategory;
+use App\Models\TransactionSubcategory;
+
+class ServiceObserver
+{
+    /**
+     * Handle the Service "created" event.
+     */
+    public function created(Service $service): void
+    {
+        // پیدا کردن دسته "خدمات" برای این سالن
+        $servicesCategory = TransactionCategory::forSalon($service->salon_id)
+            ->system()
+            ->where('name', 'خدمات')
+            ->first();
+
+        if ($servicesCategory) {
+            // ایجاد زیردسته برای این خدمت
+            TransactionSubcategory::create([
+                'category_id' => $servicesCategory->id,
+                'salon_id' => $service->salon_id,
+                'name' => $service->name,
+                'description' => $service->description,
+                'service_id' => $service->id,
+                'is_active' => true,
+                'sort_order' => 0,
+            ]);
+        }
+    }
+
+    /**
+     * Handle the Service "updated" event.
+     */
+    public function updated(Service $service): void
+    {
+        // به‌روزرسانی نام زیردسته مربوط به این خدمت
+        $subcategory = TransactionSubcategory::where('service_id', $service->id)->first();
+
+        if ($subcategory) {
+            $subcategory->update([
+                'name' => $service->name,
+                'description' => $service->description,
+            ]);
+        }
+    }
+
+    /**
+     * Handle the Service "deleted" event.
+     */
+    public function deleted(Service $service): void
+    {
+        // حذف زیردسته مربوط به این خدمت
+        TransactionSubcategory::where('service_id', $service->id)->delete();
+    }
+}

--- a/Backend/app/Providers/AppServiceProvider.php
+++ b/Backend/app/Providers/AppServiceProvider.php
@@ -11,6 +11,8 @@ use App\Models\Appointment;
 use App\Observers\AppointmentObserver;
 use App\Models\Salon;
 use App\Observers\SalonObserver;
+use App\Models\Service;
+use App\Observers\ServiceObserver;
 use Illuminate\Pagination\Paginator;
 
 class AppServiceProvider extends ServiceProvider
@@ -32,6 +34,7 @@ class AppServiceProvider extends ServiceProvider
 
         Appointment::observe(AppointmentObserver::class);
         Salon::observe(SalonObserver::class);
+        Service::observe(ServiceObserver::class);
 
         Schema::defaultStringLength(191);
 

--- a/Backend/app/Services/CashboxService.php
+++ b/Backend/app/Services/CashboxService.php
@@ -35,6 +35,18 @@ class CashboxService
         try {
             $cashbox = Cashbox::findOrFail($data['cashbox_id']);
 
+            // اگر category_id ارسال شده، نام رو از دیتابیس بگیر
+            if (!empty($data['category_id']) && empty($data['category'])) {
+                $category = \App\Models\TransactionCategory::find($data['category_id']);
+                $data['category'] = $category ? $category->name : null;
+            }
+
+            // اگر subcategory_id ارسال شده، نام رو از دیتابیس بگیر
+            if (!empty($data['subcategory_id']) && empty($data['subcategory'])) {
+                $subcategory = \App\Models\TransactionSubcategory::find($data['subcategory_id']);
+                $data['subcategory'] = $subcategory ? $subcategory->name : null;
+            }
+
             // ایجاد تراکنش صندوق
             $transaction = CashboxTransaction::create([
                 'salon_id' => $cashbox->salon_id,
@@ -42,6 +54,8 @@ class CashboxService
                 'cashbox_id' => $cashbox->id,
                 'amount' => $data['amount'],
                 'description' => $data['description'] ?? null,
+                'category_id' => $data['category_id'] ?? null,
+                'subcategory_id' => $data['subcategory_id'] ?? null,
                 'category' => $data['category'] ?? null,
                 'subcategory' => $data['subcategory'] ?? null,
                 'transaction_date' => $data['transaction_date'] ?? now()->toDateString(),
@@ -97,6 +111,18 @@ class CashboxService
                 ];
             }
 
+            // اگر category_id ارسال شده، نام رو از دیتابیس بگیر
+            if (!empty($data['category_id']) && empty($data['category'])) {
+                $category = \App\Models\TransactionCategory::find($data['category_id']);
+                $data['category'] = $category ? $category->name : null;
+            }
+
+            // اگر subcategory_id ارسال شده، نام رو از دیتابیس بگیر
+            if (!empty($data['subcategory_id']) && empty($data['subcategory'])) {
+                $subcategory = \App\Models\TransactionSubcategory::find($data['subcategory_id']);
+                $data['subcategory'] = $subcategory ? $subcategory->name : null;
+            }
+
             // ایجاد تراکنش صندوق
             $transaction = CashboxTransaction::create([
                 'salon_id' => $cashbox->salon_id,
@@ -104,6 +130,8 @@ class CashboxService
                 'cashbox_id' => $cashbox->id,
                 'amount' => $data['amount'],
                 'description' => $data['description'] ?? null,
+                'category_id' => $data['category_id'] ?? null,
+                'subcategory_id' => $data['subcategory_id'] ?? null,
                 'category' => $data['category'] ?? null,
                 'subcategory' => $data['subcategory'] ?? null,
                 'transaction_date' => $data['transaction_date'] ?? now()->toDateString(),

--- a/Backend/app/Services/Reports/AppointmentReportService.php
+++ b/Backend/app/Services/Reports/AppointmentReportService.php
@@ -1,0 +1,549 @@
+<?php
+
+namespace App\Services\Reports;
+
+use App\Models\Appointment;
+use App\Models\Service;
+use App\Models\Staff;
+use App\Models\Customer;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class AppointmentReportService extends BaseReportService
+{
+    protected $filters = [];
+
+    /**
+     * Generate preset report.
+     */
+    public function generatePresetReport($salonId, $period = 'weekly')
+    {
+        $this->salonId = $salonId;
+        $dateRange = $this->getPresetDateRange($period);
+        $this->dateFrom = $dateRange['from'];
+        $this->dateTo = $dateRange['to'];
+
+        return [
+            'period' => $period,
+            'date_range' => $this->getPersianDateRange($this->dateFrom, $this->dateTo),
+            'kpis' => $this->calculateKPIs(),
+            'charts' => $this->generateCharts(['period' => $period]),
+            'sections' => $this->generateSections(),
+        ];
+    }
+
+    /**
+     * Generate custom report.
+     */
+    public function generateCustomReport($salonId, array $filters)
+    {
+        $this->salonId = $salonId;
+        $this->applyFilters($filters);
+
+        return [
+            'filters_applied' => $this->buildFiltersSummary($filters),
+            'kpis' => $this->calculateKPIs($filters),
+            'charts' => $this->generateCharts($filters),
+            'sections' => $this->generateSections($filters),
+        ];
+    }
+
+    /**
+     * Apply custom filters.
+     */
+    protected function applyFilters(array $filters)
+    {
+        // Only override date/time if explicitly provided in filters
+        if (isset($filters['date_from'])) {
+            $this->dateFrom = $filters['date_from'];
+        }
+        if (isset($filters['date_to'])) {
+            $this->dateTo = $filters['date_to'];
+        }
+        if (isset($filters['time_from'])) {
+            $this->timeFrom = $filters['time_from'];
+        }
+        if (isset($filters['time_to'])) {
+            $this->timeTo = $filters['time_to'];
+        }
+        $this->filters = $filters;
+    }
+
+    /**
+     * Calculate KPIs.
+     */
+    protected function calculateKPIs(array $filters = [])
+    {
+        $this->applyFilters($filters);
+        
+        // Build base query
+        $baseQuery = Appointment::where('salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->when($this->timeFrom, function ($q) {
+                $q->whereTime('start_time', '>=', $this->timeFrom);
+            })
+            ->when($this->timeTo, function ($q) {
+                $q->whereTime('start_time', '<=', $this->timeTo);
+            });
+
+        // Apply status filter
+        if (!empty($filters['status']) && !in_array('all', $filters['status'])) {
+            $baseQuery->whereIn('status', $filters['status']);
+        }
+
+        // Apply personnel filter
+        if (!empty($filters['personnel_ids']) && !in_array(0, $filters['personnel_ids'])) {
+            $baseQuery->whereIn('staff_id', $filters['personnel_ids']);
+        }
+
+        // Apply customer filter
+        if (!empty($filters['customer_ids']) && !in_array(0, $filters['customer_ids'])) {
+            $baseQuery->whereIn('customer_id', $filters['customer_ids']);
+        }
+
+        // Apply service filter
+        if (!empty($filters['service_ids']) && !in_array(0, $filters['service_ids'])) {
+            $baseQuery->whereHas('services', function ($q) use ($filters) {
+                $q->whereIn('service_id', $filters['service_ids']);
+            });
+        }
+
+        // Total appointments
+        $totalAppointments = (clone $baseQuery)->count();
+
+        // Completed appointments
+        $completedAppointments = (clone $baseQuery)->where('status', 'completed')->count();
+
+        // Cancelled appointments
+        $cancelledAppointments = (clone $baseQuery)->whereIn('status', ['canceled', 'cancelled'])->count();
+
+        // Pending appointments
+        $pendingAppointments = (clone $baseQuery)->where('status', 'pending')->count();
+
+        // Confirmed appointments
+        $confirmedAppointments = (clone $baseQuery)->where('status', 'confirmed')->count();
+
+        // No-show appointments
+        $noShowAppointments = (clone $baseQuery)->where('status', 'no_show')->count();
+
+        // Completion rate
+        $completionRate = $totalAppointments > 0 ? ($completedAppointments / $totalAppointments) * 100 : 0;
+
+        // Cancellation rate
+        $cancellationRate = $totalAppointments > 0 ? ($cancelledAppointments / $totalAppointments) * 100 : 0;
+
+        // Average appointments per day
+        if ($this->dateFrom && $this->dateTo) {
+            $daysDiff = Carbon::parse($this->dateFrom)->diffInDays(Carbon::parse($this->dateTo)) + 1;
+            $avgPerDay = $daysDiff > 0 ? $totalAppointments / $daysDiff : 0;
+        } else {
+            $avgPerDay = 0;
+        }
+
+        // Peak hour (most appointments)
+        $peakHour = (clone $baseQuery)
+            ->select(DB::raw('HOUR(start_time) as hour'), DB::raw('COUNT(*) as count'))
+            ->groupBy('hour')
+            ->orderByDesc('count')
+            ->first();
+
+        // Off-peak hour (least appointments)
+        $offPeakHour = (clone $baseQuery)
+            ->select(DB::raw('HOUR(start_time) as hour'), DB::raw('COUNT(*) as count'))
+            ->groupBy('hour')
+            ->orderBy('count', 'asc')
+            ->first();
+
+        // Most requested service
+        $mostRequestedService = DB::table('appointment_service')
+            ->join('appointments', 'appointment_service.appointment_id', '=', 'appointments.id')
+            ->join('services', 'appointment_service.service_id', '=', 'services.id')
+            ->where('appointments.salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointments.appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointments.appointment_date', '<=', $this->dateTo);
+            })
+            ->select('services.name', DB::raw('COUNT(*) as count'))
+            ->groupBy('services.id', 'services.name')
+            ->orderByDesc('count')
+            ->first();
+
+        // Most active staff
+        $mostActiveStaff = (clone $baseQuery)
+            ->select('staff_id', DB::raw('COUNT(*) as count'))
+            ->whereNotNull('staff_id')
+            ->groupBy('staff_id')
+            ->orderByDesc('count')
+            ->with('staff:id,full_name')
+            ->first();
+
+        // Total revenue
+        $totalRevenue = (clone $baseQuery)
+            ->where('status', 'completed')
+            ->sum('total_price');
+
+        // Average revenue per appointment
+        $avgRevenue = $completedAppointments > 0 ? $totalRevenue / $completedAppointments : 0;
+
+        // Unique customers
+        $uniqueCustomers = (clone $baseQuery)->distinct('customer_id')->count('customer_id');
+
+        return [
+            'total_appointments' => $totalAppointments,
+            'completed_appointments' => $completedAppointments,
+            'cancelled_appointments' => $cancelledAppointments,
+            'pending_appointments' => $pendingAppointments,
+            'confirmed_appointments' => $confirmedAppointments,
+            'no_show_appointments' => $noShowAppointments,
+            'completion_rate' => round($completionRate, 1),
+            'cancellation_rate' => round($cancellationRate, 1),
+            'average_per_day' => round($avgPerDay, 1),
+            'peak_hour' => $peakHour ? $peakHour->hour . ':00' : 'نامشخص',
+            'off_peak_hour' => $offPeakHour ? $offPeakHour->hour . ':00' : 'نامشخص',
+            'most_requested_service' => $mostRequestedService ? $mostRequestedService->name : 'نامشخص',
+            'most_active_staff' => $mostActiveStaff && $mostActiveStaff->staff ? 
+                $mostActiveStaff->staff->full_name : 'نامشخص',
+            'total_revenue' => round($totalRevenue, 2),
+            'average_revenue_per_appointment' => round($avgRevenue, 2),
+            'unique_customers' => $uniqueCustomers,
+        ];
+    }
+
+    /**
+     * Generate charts data.
+     */
+    protected function generateCharts(array $filters = [])
+    {
+        $grouping = $this->getChartGrouping($filters['period'] ?? null);
+        
+        // Appointments by time period
+        $appointmentsByPeriod = Appointment::where('salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->selectRaw(str_replace('{{column}}', 'appointment_date', $grouping['sql']) . ', COUNT(*) as count')
+            ->groupBy('group_key')
+            ->orderBy('group_key')
+            ->get();
+
+        $labels = $grouping['labels'];
+        $data = array_fill(0, count($labels), 0);
+
+        foreach ($appointmentsByPeriod as $item) {
+            if ($grouping['type'] === 'weekday') {
+                $mapping = [7 => 0, 1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5, 6 => 6];
+                $index = $mapping[$item->group_key] ?? 0;
+                $data[$index] = $item->count;
+            } elseif ($grouping['type'] === 'day') {
+                $index = $item->group_key - 1;
+                if ($index >= 0 && $index < count($data)) {
+                    $data[$index] = $item->count;
+                }
+            } elseif ($grouping['type'] === 'month') {
+                // For monthly grouping, we need to map the date to Persian month
+                try {
+                    $date = Carbon::parse($item->group_key . '-01');
+                    $verta = new \Hekmatinasser\Verta\Verta($date);
+                    $monthIndex = $verta->month - 1;
+                    if ($monthIndex >= 0 && $monthIndex < 12) {
+                        $data[$monthIndex] += $item->count;
+                    }
+                } catch (\Exception $e) {
+                    // Skip invalid dates
+                }
+            }
+        }
+
+        // Appointments by status
+        $appointmentsByStatus = Appointment::where('salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->select('status', DB::raw('COUNT(*) as count'))
+            ->groupBy('status')
+            ->get();
+
+        $statusLabels = [];
+        $statusData = [];
+        $statusMapping = [
+            'pending' => 'در انتظار',
+            'confirmed' => 'تایید شده',
+            'completed' => 'تکمیل شده',
+            'canceled' => 'لغو شده',
+            'cancelled' => 'لغو شده',
+            'no_show' => 'عدم حضور',
+        ];
+
+        foreach ($appointmentsByStatus as $item) {
+            $statusLabels[] = $statusMapping[$item->status] ?? $item->status;
+            $statusData[] = $item->count;
+        }
+
+        // Appointments by hour
+        $appointmentsByHour = Appointment::where('salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->select(DB::raw('HOUR(start_time) as hour'), DB::raw('COUNT(*) as count'))
+            ->groupBy('hour')
+            ->orderBy('hour')
+            ->get();
+
+        $hourLabels = [];
+        $hourData = [];
+        
+        foreach ($appointmentsByHour as $item) {
+            $hourLabels[] = $item->hour . ':00';
+            $hourData[] = $item->count;
+        }
+
+        return [
+            'appointments_by_period' => [
+                'labels' => $labels,
+                'data' => $data,
+            ],
+            'appointments_by_status' => [
+                'labels' => $statusLabels,
+                'data' => $statusData,
+            ],
+            'appointments_by_hour' => [
+                'labels' => $hourLabels,
+                'data' => $hourData,
+            ],
+        ];
+    }
+
+    /**
+     * Generate sections.
+     */
+    protected function generateSections(array $filters = [])
+    {
+        return [
+            'appointments_by_service' => $this->getAppointmentsByService(),
+            'appointments_by_staff' => $this->getAppointmentsByStaff(),
+            'cancellation_analysis' => $this->getCancellationAnalysis(),
+            'revenue_analysis' => $this->getRevenueAnalysis(),
+        ];
+    }
+
+    /**
+     * Get appointments grouped by service.
+     */
+    protected function getAppointmentsByService()
+    {
+        return DB::table('appointment_service')
+            ->join('appointments', 'appointment_service.appointment_id', '=', 'appointments.id')
+            ->join('services', 'appointment_service.service_id', '=', 'services.id')
+            ->where('appointments.salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointments.appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointments.appointment_date', '>=', $this->dateTo);
+            })
+            ->select('services.name', DB::raw('COUNT(*) as total_appointments'))
+            ->groupBy('services.id', 'services.name')
+            ->orderByDesc('total_appointments')
+            ->get()
+            ->map(function ($item) {
+                return [
+                    'service_name' => $item->name,
+                    'total_appointments' => $item->total_appointments,
+                ];
+            });
+    }
+
+    /**
+     * Get appointments grouped by staff.
+     */
+    protected function getAppointmentsByStaff()
+    {
+        return Appointment::where('salon_id', $this->salonId)
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->whereNotNull('staff_id')
+            ->select('staff_id', DB::raw('COUNT(*) as total_appointments'))
+            ->groupBy('staff_id')
+            ->orderByDesc('total_appointments')
+            ->with('staff:id,full_name')
+            ->get()
+            ->map(function ($item) {
+                return [
+                    'staff_name' => $item->staff ? $item->staff->full_name : 'نامشخص',
+                    'total_appointments' => $item->total_appointments,
+                ];
+            });
+    }
+
+    /**
+     * Get cancellation analysis.
+     */
+    protected function getCancellationAnalysis()
+    {
+        // Cancellations by weekday
+        $byWeekday = Appointment::where('salon_id', $this->salonId)
+            ->whereIn('status', ['canceled', 'cancelled'])
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->select(DB::raw('DAYOFWEEK(appointment_date) as day'), DB::raw('COUNT(*) as count'))
+            ->groupBy('day')
+            ->orderByDesc('count')
+            ->get();
+
+        $dayMapping = [
+            7 => 'شنبه',
+            1 => 'یکشنبه',
+            2 => 'دوشنبه',
+            3 => 'سه‌شنبه',
+            4 => 'چهارشنبه',
+            5 => 'پنج‌شنبه',
+            6 => 'جمعه',
+        ];
+
+        $byWeekdayFormatted = $byWeekday->map(function ($item) use ($dayMapping) {
+            return [
+                'day' => $dayMapping[$item->day] ?? 'نامشخص',
+                'count' => $item->count,
+            ];
+        });
+
+        // Cancellations by hour
+        $byHour = Appointment::where('salon_id', $this->salonId)
+            ->whereIn('status', ['canceled', 'cancelled'])
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointment_date', '<=', $this->dateTo);
+            })
+            ->select(DB::raw('HOUR(start_time) as hour'), DB::raw('COUNT(*) as count'))
+            ->groupBy('hour')
+            ->orderByDesc('count')
+            ->get()
+            ->map(function ($item) {
+                return [
+                    'hour' => $item->hour . ':00',
+                    'count' => $item->count,
+                ];
+            });
+
+        return [
+            'by_weekday' => $byWeekdayFormatted,
+            'by_hour' => $byHour,
+        ];
+    }
+
+    /**
+     * Get revenue analysis.
+     */
+    protected function getRevenueAnalysis()
+    {
+        $revenueByService = DB::table('appointment_service')
+            ->join('appointments', 'appointment_service.appointment_id', '=', 'appointments.id')
+            ->join('services', 'appointment_service.service_id', '=', 'services.id')
+            ->where('appointments.salon_id', $this->salonId)
+            ->where('appointments.status', 'completed')
+            ->when($this->dateFrom, function ($q) {
+                $q->whereDate('appointments.appointment_date', '>=', $this->dateFrom);
+            })
+            ->when($this->dateTo, function ($q) {
+                $q->whereDate('appointments.appointment_date', '<=', $this->dateTo);
+            })
+            ->select('services.name', DB::raw('SUM(appointments.total_price) as total_revenue'))
+            ->groupBy('services.id', 'services.name')
+            ->orderByDesc('total_revenue')
+            ->get()
+            ->map(function ($item) {
+                return [
+                    'service_name' => $item->name,
+                    'total_revenue' => round($item->total_revenue, 2),
+                ];
+            });
+
+        return [
+            'by_service' => $revenueByService,
+        ];
+    }
+
+    /**
+     * Build filters summary for display (override).
+     */
+    protected function buildFiltersSummary($filters)
+    {
+        $summary = parent::buildFiltersSummary($filters);
+
+        // Add status filter
+        if (!empty($filters['status']) && !in_array('all', $filters['status'])) {
+            $statusMapping = [
+                'pending' => 'در انتظار',
+                'confirmed' => 'تایید شده',
+                'completed' => 'تکمیل شده',
+                'canceled' => 'لغو شده',
+                'cancelled' => 'لغو شده',
+                'no_show' => 'عدم حضور',
+            ];
+            $statusNames = array_map(function($status) use ($statusMapping) {
+                return $statusMapping[$status] ?? $status;
+            }, $filters['status']);
+            $summary[] = ['label' => 'وضعیت', 'value' => implode('، ', $statusNames)];
+        } elseif (isset($filters['status']) && in_array('all', $filters['status'])) {
+            $summary[] = ['label' => 'وضعیت', 'value' => 'همه موارد'];
+        }
+
+        // Add personnel filter
+        if (!empty($filters['personnel_ids']) && !in_array(0, $filters['personnel_ids'])) {
+            $personnelNames = Staff::whereIn('id', $filters['personnel_ids'])
+                ->pluck('full_name')
+                ->implode('، ');
+            $summary[] = ['label' => 'پرسنل', 'value' => $personnelNames ?: 'نامشخص'];
+        } elseif (isset($filters['personnel_ids']) && in_array(0, $filters['personnel_ids'])) {
+            $summary[] = ['label' => 'پرسنل', 'value' => 'همه موارد'];
+        }
+
+        // Add customer filter
+        if (!empty($filters['customer_ids']) && !in_array(0, $filters['customer_ids'])) {
+            $customerNames = Customer::whereIn('id', $filters['customer_ids'])
+                ->pluck('full_name')
+                ->implode('، ');
+            $summary[] = ['label' => 'مشتریان', 'value' => $customerNames ?: 'نامشخص'];
+        } elseif (isset($filters['customer_ids']) && in_array(0, $filters['customer_ids'])) {
+            $summary[] = ['label' => 'مشتریان', 'value' => 'همه موارد'];
+        }
+
+        // Add service filter
+        if (!empty($filters['service_ids']) && !in_array(0, $filters['service_ids'])) {
+            $serviceNames = Service::whereIn('id', $filters['service_ids'])
+                ->pluck('name')
+                ->implode('، ');
+            $summary[] = ['label' => 'خدمات', 'value' => $serviceNames ?: 'نامشخص'];
+        } elseif (isset($filters['service_ids']) && in_array(0, $filters['service_ids'])) {
+            $summary[] = ['label' => 'خدمات', 'value' => 'همه موارد'];
+        }
+
+        return $summary;
+    }
+}

--- a/Backend/app/Services/Reports/PersonnelReportService.php
+++ b/Backend/app/Services/Reports/PersonnelReportService.php
@@ -51,10 +51,19 @@ class PersonnelReportService extends BaseReportService
      */
     protected function applyFilters(array $filters)
     {
-        $this->dateFrom = $filters['date_from'] ?? null;
-        $this->dateTo = $filters['date_to'] ?? null;
-        $this->timeFrom = $filters['time_from'] ?? null;
-        $this->timeTo = $filters['time_to'] ?? null;
+        // Only override date/time if explicitly provided in filters
+        if (isset($filters['date_from'])) {
+            $this->dateFrom = $filters['date_from'];
+        }
+        if (isset($filters['date_to'])) {
+            $this->dateTo = $filters['date_to'];
+        }
+        if (isset($filters['time_from'])) {
+            $this->timeFrom = $filters['time_from'];
+        }
+        if (isset($filters['time_to'])) {
+            $this->timeTo = $filters['time_to'];
+        }
         $this->filters = $filters;
     }
 

--- a/Backend/database/migrations/2026_02_18_100000_create_transaction_categories_table.php
+++ b/Backend/database/migrations/2026_02_18_100000_create_transaction_categories_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // جدول دسته‌بندی‌های تراکنش
+        Schema::create('transaction_categories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('salon_id')->constrained('salons')->onDelete('cascade');
+            $table->string('name'); // نام دسته‌بندی
+            $table->string('type')->default('both'); // both, income, expense
+            $table->text('description')->nullable();
+            $table->boolean('is_system')->default(false); // آیا سیستمی است (خدمات)
+            $table->boolean('is_active')->default(true);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['salon_id', 'is_active'], 'tc_salon_active_idx');
+            $table->index(['salon_id', 'type'], 'tc_salon_type_idx');
+        });
+
+        // جدول زیردسته‌های تراکنش
+        Schema::create('transaction_subcategories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained('transaction_categories')->onDelete('cascade');
+            $table->foreignId('salon_id')->constrained('salons')->onDelete('cascade');
+            $table->string('name'); // نام زیردسته
+            $table->text('description')->nullable();
+            
+            // برای لینک به خدمات سالن (اختیاری)
+            $table->foreignId('service_id')->nullable()->constrained('services')->onDelete('cascade');
+            
+            $table->boolean('is_active')->default(true);
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['category_id', 'is_active'], 'ts_category_active_idx');
+            $table->index(['salon_id', 'service_id'], 'ts_salon_service_idx');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('transaction_subcategories');
+        Schema::dropIfExists('transaction_categories');
+    }
+};

--- a/Backend/database/migrations/2026_02_18_200000_add_category_ids_to_cashbox_transactions.php
+++ b/Backend/database/migrations/2026_02_18_200000_add_category_ids_to_cashbox_transactions.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cashbox_transactions', function (Blueprint $table) {
+            // اضافه کردن foreign key به دسته‌بندی و زیردسته
+            $table->foreignId('category_id')->nullable()->after('description')->constrained('transaction_categories')->onDelete('set null');
+            $table->foreignId('subcategory_id')->nullable()->after('category_id')->constrained('transaction_subcategories')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cashbox_transactions', function (Blueprint $table) {
+            $table->dropForeign(['category_id']);
+            $table->dropForeign(['subcategory_id']);
+            $table->dropColumn(['category_id', 'subcategory_id']);
+        });
+    }
+};

--- a/Backend/database/seeders/Salon1043ReportDataSeeder.php
+++ b/Backend/database/seeders/Salon1043ReportDataSeeder.php
@@ -35,6 +35,9 @@ class Salon1043ReportDataSeeder extends Seeder
         
         if (!$this->salon) {
             $this->createSalon();
+        } else {
+            // Salon exists, but make sure it has an owner
+            $this->ensureSalonHasOwner();
         }
 
         // Clean up existing data for this salon before seeding
@@ -97,15 +100,14 @@ class Salon1043ReportDataSeeder extends Seeder
             ['email' => 'salon1043@test.com'],
             [
                 'name' => 'مدیر سالن 1043',
+                'mobile' => '09121234043',
                 'password' => bcrypt('password'),
-                'phone_number' => '09121234043',
-                'role' => 'salon_owner',
             ]
         );
 
         $this->salon = Salon::create([
             'id' => $this->salonId,
-            'owner_id' => $owner->id,
+            'user_id' => $owner->id,
             'name' => 'سالن زیبایی شماره 1043',
             'business_category_id' => 1,
             'address' => 'تهران، خیابان ولیعصر، پلاک 1043',
@@ -130,6 +132,30 @@ class Salon1043ReportDataSeeder extends Seeder
         $owner->update(['active_salon_id' => $this->salonId]);
 
         $this->command->info("✅ سالن 1043 ایجاد شد");
+    }
+
+    private function ensureSalonHasOwner(): void
+    {
+        // Check if salon has an owner
+        if (!$this->salon->user_id) {
+            // Find or create owner user
+            $owner = User::firstOrCreate(
+                ['email' => 'salon1043@test.com'],
+                [
+                    'name' => 'مدیر سالن 1043',
+                    'mobile' => '09121234043',
+                    'password' => bcrypt('password'),
+                ]
+            );
+
+            // Update salon with owner
+            $this->salon->update(['user_id' => $owner->id]);
+            $owner->update(['active_salon_id' => $this->salonId]);
+
+            $this->command->info("✅ مالک سالن 1043 ایجاد و به سالن اختصاص داده شد");
+        } else {
+            $this->command->info("✅ سالن 1043 از قبل موجود است و مالک دارد");
+        }
     }
 
     private function createStaff(): void

--- a/Backend/database/seeders/TransactionCategorySeeder.php
+++ b/Backend/database/seeders/TransactionCategorySeeder.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Salon;
+use App\Models\Service;
+use App\Models\TransactionCategory;
+use App\Models\TransactionSubcategory;
+use Illuminate\Database\Seeder;
+
+class TransactionCategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // این seeder برای سالن‌های موجود، دسته "خدمات" و زیردسته‌هایش رو ایجاد می‌کنه
+        $salons = Salon::all();
+
+        foreach ($salons as $salon) {
+            $this->createServicesCategory($salon);
+        }
+    }
+
+    /**
+     * ایجاد دسته "خدمات" برای سالن
+     */
+    public static function createServicesCategory(Salon $salon): TransactionCategory
+    {
+        // بررسی اینکه آیا قبلاً ساخته شده یا نه
+        $category = TransactionCategory::forSalon($salon->id)
+            ->system()
+            ->where('name', 'خدمات')
+            ->first();
+
+        if (!$category) {
+            $category = TransactionCategory::create([
+                'salon_id' => $salon->id,
+                'name' => 'خدمات',
+                'type' => TransactionCategory::TYPE_INCOME, // خدمات فقط برای ورودی
+                'description' => 'دسته‌بندی خدمات ارائه شده توسط سالن',
+                'is_system' => true,
+                'is_active' => true,
+                'sort_order' => 0,
+            ]);
+        }
+
+        // ایجاد زیردسته برای هر خدمت سالن
+        static::syncServicesAsSubcategories($salon, $category);
+
+        return $category;
+    }
+
+    /**
+     * همگام‌سازی خدمات سالن با زیردسته‌ها
+     */
+    public static function syncServicesAsSubcategories(Salon $salon, TransactionCategory $category): void
+    {
+        $services = Service::where('salon_id', $salon->id)->get();
+
+        foreach ($services as $service) {
+            // بررسی اینکه آیا زیردسته برای این خدمت وجود دارد
+            $existingSubcategory = TransactionSubcategory::forCategory($category->id)
+                ->where('service_id', $service->id)
+                ->first();
+
+            if (!$existingSubcategory) {
+                TransactionSubcategory::create([
+                    'category_id' => $category->id,
+                    'salon_id' => $salon->id,
+                    'name' => $service->name,
+                    'description' => $service->description,
+                    'service_id' => $service->id,
+                    'is_active' => true,
+                    'sort_order' => 0,
+                ]);
+            }
+        }
+    }
+}

--- a/Backend/routes/api.php
+++ b/Backend/routes/api.php
@@ -314,6 +314,23 @@ Route::middleware('auth:api')->group(function () {
                 Route::post('{cashbox}/recalculate', [\App\Http\Controllers\CashboxController::class, 'recalculateBalance'])->name('recalculate');
             });
 
+            // Transaction Categories Management Routes - مدیریت دسته‌بندی و زیردسته‌بندی تراکنش‌ها
+            Route::prefix('transaction-categories')->name('transaction_categories.')->group(function () {
+                // دسته‌بندی‌ها
+                Route::get('/', [\App\Http\Controllers\TransactionCategoryController::class, 'index'])->name('index');
+                Route::post('/', [\App\Http\Controllers\TransactionCategoryController::class, 'store'])->name('store');
+                Route::get('{category}', [\App\Http\Controllers\TransactionCategoryController::class, 'show'])->name('show');
+                Route::put('{category}', [\App\Http\Controllers\TransactionCategoryController::class, 'update'])->name('update');
+                Route::delete('{category}', [\App\Http\Controllers\TransactionCategoryController::class, 'destroy'])->name('destroy');
+                
+                // زیردسته‌ها
+                Route::get('{category}/subcategories', [\App\Http\Controllers\TransactionCategoryController::class, 'subcategories'])->name('subcategories.index');
+                Route::post('{category}/subcategories', [\App\Http\Controllers\TransactionCategoryController::class, 'storeSubcategory'])->name('subcategories.store');
+                Route::get('{category}/subcategories/{subcategory}', [\App\Http\Controllers\TransactionCategoryController::class, 'showSubcategory'])->name('subcategories.show');
+                Route::put('{category}/subcategories/{subcategory}', [\App\Http\Controllers\TransactionCategoryController::class, 'updateSubcategory'])->name('subcategories.update');
+                Route::delete('{category}/subcategories/{subcategory}', [\App\Http\Controllers\TransactionCategoryController::class, 'destroySubcategory'])->name('subcategories.destroy');
+            });
+
             Route::get('overview/stats', [DashboardController::class, 'getSalonStats'])->name('overview.stats');
 
             Route::prefix('settings')->name('settings.')->group(function () {
@@ -518,6 +535,10 @@ Route::middleware('auth:api')->prefix('reports')->name('reports.')->group(functi
     // Reservation Reports
     Route::get('reservations/preset', [ReportController::class, 'reservationsPreset'])->name('reservations.preset');
     Route::post('reservations/custom', [ReportController::class, 'reservationsCustom'])->name('reservations.custom');
+    
+    // Appointment Reports (Custom)
+    Route::get('appointments/preset', [ReportController::class, 'appointmentsPreset'])->name('appointments.preset');
+    Route::post('appointments/custom', [ReportController::class, 'appointmentsCustom'])->name('appointments.custom');
     
     // Finance Reports
     Route::get('finance/preset', [ReportController::class, 'financePreset'])->name('finance.preset');


### PR DESCRIPTION
- Created TransactionCategory and TransactionSubcategory models with relationships and scopes.
- Implemented SalonObserver to create default "Services" category upon salon creation.
- Added ServiceObserver to manage subcategories for services.
- Updated CashboxService to handle category and subcategory IDs in transactions.
- Developed AppointmentReportService for generating detailed appointment reports.
- Introduced PersonnelReportService with enhanced filter application.
- Created migrations for transaction categories and subcategories tables.
- Added foreign keys for category and subcategory in cashbox_transactions table.
- Implemented TransactionCategorySeeder to seed default categories and subcategories.
- Updated API routes for transaction categories and subcategories management.